### PR TITLE
feat: allow for unknown actions

### DIFF
--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -64,7 +64,7 @@ pub async fn handle_action(
             }
         }
         ActionType::Unknown => {
-            warn!("received unknown action type with payload `{:?}`", payload);
+            warn!("received unknown action type `{:?}` with payload `{:?}`", r#type, payload);
         }
     };
 

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -1,4 +1,4 @@
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::did::persistence::load_existing_keypair;
 use crate::state::actions::{Action, ActionType};
@@ -17,8 +17,6 @@ pub async fn handle_action(
     window: tauri::Window,
 ) -> Result<(), String> {
     info!("received action `{:?}` with payload `{:?}`", r#type, payload);
-
-    // TODO: be more redux-idiomatic: do not deserialize to "known" actions, but return the state unchanged if the action is unknown
 
     match r#type {
         ActionType::GetState => {
@@ -64,6 +62,9 @@ pub async fn handle_action(
             {
                 save_state(TransferState::from(app_state.inner())).await.ok();
             }
+        }
+        ActionType::Unknown => {
+            warn!("received unknown action type with payload `{:?}`", payload);
         }
     };
 

--- a/src-tauri/src/state/actions.rs
+++ b/src-tauri/src/state/actions.rs
@@ -27,6 +27,7 @@ pub enum ActionType {
     #[serde(rename = "[DEV] Load profile")]
     LoadDevProfile,
     #[serde(other)]
+    #[ts(skip)]
     Unknown,
 }
 

--- a/src-tauri/src/state/actions.rs
+++ b/src-tauri/src/state/actions.rs
@@ -13,7 +13,7 @@ pub struct Action {
 }
 
 /// Actions that the backend knows how to handle (reduce).
-#[derive(Serialize, Deserialize, Debug, TS)]
+#[derive(Serialize, Deserialize, Debug, TS, PartialEq)]
 #[ts(export)]
 pub enum ActionType {
     #[serde(rename = "[App] Get state")]
@@ -26,4 +26,23 @@ pub enum ActionType {
     SetLocale,
     #[serde(rename = "[DEV] Load profile")]
     LoadDevProfile,
+    #[serde(other)]
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_action_type_deserialization() {
+        assert_eq!(
+            ActionType::GetState,
+            serde_json::from_str(r#""[App] Get state""#).unwrap(),
+        );
+        assert_eq!(
+            ActionType::Unknown,
+            serde_json::from_str(r#""Unknown action""#).unwrap(),
+        );
+    }
 }


### PR DESCRIPTION
# Description of change
Resolves the following "TODO":
```
    // TODO: be more redux-idiomatic: do not deserialize to "known" actions, but return the state unchanged if the action is unknown
```

Running `cargo test` unfortunately will result in some minor warnings:
```
warning: failed to parse serde attribute
  | 
  | #[serde(other)]
  | 
  = note: ts-rs failed to parse this attribute. It will be ignored.
```

These warning simply caused by `ts-rs` not supporting all serde attributes yet: https://docs.rs/ts-rs/latest/ts_rs/trait.TS.html#serde-compatibility.

In our case we can just simply ignore these warnings.

## Links to any relevant issues
n/a

## How the change has been tested
Tested with a simple unit test testing for bot a known action string and a unknown action string.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
