### PR TITLE
feat: init error handling

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,6 +2968,7 @@ dependencies = [
  "tauri-plugin-barcode-scanner",
  "tauri-plugin-log",
  "tempfile",
+ "thiserror",
  "tokio",
  "ts-rs",
  "url",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ uuid = { version = "1.4", features = ["v4", "fast-rng"] }
 chrono = "0.4"
 sha256 = "1.4"
 derivative = "2.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 tauri = { version = "=2.0.0-alpha.17", features = ["rustls-tls", "test"] }

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -114,7 +114,9 @@ pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
                 .await
                 .ok();
             } else {
-                info!("Unable to parse QR code data");
+                let message = format!("Unable to parse QR code with content: `{:?}`", form_urlencoded);
+                warn!("{message}");
+                app_state.debug_messages.lock().unwrap().push(message);
             };
             save_state(app_state).await.ok();
         }
@@ -215,7 +217,7 @@ pub async fn handle_action<R: tauri::Runtime>(
     _app_handle: tauri::AppHandle<R>,
     app_state: tauri::State<'_, AppState>,
     window: tauri::Window<R>,
-) -> Result<(), String> {
+) -> anyhow::Result<(), String> {
     handle_action_inner(action, _app_handle, app_state.inner()).await.ok();
 
     emit_event(window, app_state.inner()).ok();

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -162,7 +162,7 @@ pub async fn handle_action<R: tauri::Runtime>(
                 debug_messages.remove(0);
             }
             debug_messages.push_back(format!(
-                "{}: {:?}",
+                "{} {:?}",
                 chrono::Utc::now().format("[%Y-%m-%d][%H:%M:%S]").to_string(),
                 error
             ));

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -46,7 +46,7 @@ pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
                 });
             }
 
-            *app_state.dev_mode_enabled.lock().unwrap() = loaded_state.dev_mode_enabled.lock().unwrap().clone();
+            *app_state.dev_mode_enabled.lock().unwrap() = *loaded_state.dev_mode_enabled.lock().unwrap();
             // TODO: uncomment the following line for LOCAL DEVELOPMENT (DEV_MODE)
             // *app_state.dev_mode_enabled.lock().unwrap() = true;
             Ok(())
@@ -163,7 +163,7 @@ pub async fn handle_action<R: tauri::Runtime>(
             }
             debug_messages.push_back(format!(
                 "{} {:?}",
-                chrono::Utc::now().format("[%Y-%m-%d][%H:%M:%S]").to_string(),
+                chrono::Utc::now().format("[%Y-%m-%d][%H:%M:%S]"),
                 error
             ));
             warn!("state update failed `{}`", error);

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -165,7 +165,7 @@ pub async fn handle_action<R: tauri::Runtime>(
             // If the state update fails, we revert to the unaltered state and add the error to the debug messages.
             {
                 let debug_messages = &mut unaltered_state.debug_messages.lock().unwrap();
-                while debug_messages.len() > 1000 {
+                while debug_messages.len() > 100 {
                     debug_messages.remove(0);
                 }
                 debug_messages.push_back(format!(
@@ -178,7 +178,7 @@ pub async fn handle_action<R: tauri::Runtime>(
 
             // Save and emit the unaltered state including the error message.
             save_state(&unaltered_state).await.ok();
-            emit_event(window.clone(), &unaltered_state).ok();
+            emit_event(window, &unaltered_state).ok();
         }
     }
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,5 +1,6 @@
 use crate::state::actions::ActionType;
 use std::error::Error;
+use uuid::Uuid;
 
 // TODO: needs revision/refactor + needs oid4vc libs to properly implement error handling.
 #[derive(thiserror::Error)]
@@ -9,7 +10,7 @@ pub enum AppError {
     #[error("Required payload value is missing: {0}")]
     MissingPayloadValueError(&'static str),
     #[error("Unable to parse QR code with content: `{0}`")]
-    InvalidQRCodeError(&'static str),
+    InvalidQRCodeError(String),
     #[error("Received unknown action type `{r#type:?}` with payload: `{payload:?}`")]
     UnknownActionTypeError {
         r#type: ActionType,
@@ -18,10 +19,14 @@ pub enum AppError {
     #[error("No `{0}` manager found in the state")]
     MissingManagerError(&'static str),
     #[error("{extension} authorization request cannot be validated")]
-    OID4VCProviderManagerError {
+    OID4VCAuthorizationRequestError {
         extension: &'static str,
         source: serde_json::Error,
     },
+    #[error("Error while initializing OID4VC provider manager")]
+    OID4VCProviderManagerError(#[source] anyhow::Error),
+    #[error("Error while fetching DID identifier from OID4VC subject")]
+    OID4VCSubjectIdentifierError(#[source] anyhow::Error),
     #[error("Missing required parameter `{0}` in authorization request")]
     MissingAuthorizationRequestParameterError(&'static str),
     #[error("Invalid authorization request: {0}")]
@@ -62,6 +67,8 @@ pub enum AppError {
     InvalidOfferIndicesError(#[source] serde_json::Error),
     #[error("No `{0}` found in the state")]
     MissingStateParameterError(&'static str),
+    #[error("Failed to create stronghold")]
+    StrongholdCreationError(#[source] anyhow::Error),
     #[error("Failed to load stronghold")]
     StrongholdLoadingError(#[source] anyhow::Error),
     #[error("Failed to delete credential from stronghold")]
@@ -70,6 +77,12 @@ pub enum AppError {
     StrongholdInsertionError(#[source] anyhow::Error),
     #[error("Error while loading credentials from stronghold")]
     StrongholdValuesError(#[source] anyhow::Error),
+    #[error("No credential record found for id `{0}`")]
+    StrongholdMissingCredentialError(Uuid),
+    #[error("Failed to retrieve public key from stronghold")]
+    StrongholdPublicKeyError(#[source] anyhow::Error),
+    #[error("Failed to delete state file")]
+    StateFileDeletionError(#[source] anyhow::Error),
 }
 
 impl std::fmt::Debug for AppError {

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,83 @@
+use crate::state::actions::ActionType;
+use std::error::Error;
+
+// TODO: needs revision/refactor + needs oid4vc libs to properly implement error handling.
+#[derive(thiserror::Error)]
+pub enum AppError {
+    #[error("Required payload is missing")]
+    MissingPayloadError,
+    #[error("Required payload value is missing: {0}")]
+    MissingPayloadValueError(&'static str),
+    #[error("Unable to parse QR code with content: `{0}`")]
+    InvalidQRCodeError(&'static str),
+    #[error("Received unknown action type `{r#type:?}` with payload: `{payload:?}`")]
+    UnknownActionTypeError {
+        r#type: ActionType,
+        payload: Option<serde_json::Value>,
+    },
+    #[error("No `{0}` manager found in the state")]
+    MissingManagerError(&'static str),
+    #[error("{extension} authorization request cannot be validated")]
+    OID4VCProviderManagerError {
+        extension: &'static str,
+        source: serde_json::Error,
+    },
+    #[error("Missing required parameter `{0}` in authorization request")]
+    MissingAuthorizationRequestParameterError(&'static str),
+    #[error("Invalid authorization request: {0}")]
+    InvalidAuthorizationRequest(serde_json::Value),
+    #[error("Invalid credential offer")]
+    InvalidCredentialOffer(#[source] serde_json::Error),
+    #[error("Could not find a matching credential for input descriptor")]
+    NoMatchingCredentialError,
+    #[error("Failed to generate authorization response")]
+    GenerateAuthorizationResponseError(#[source] anyhow::Error),
+    #[error("Failed to send authorization response")]
+    SendAuthorizationResponseError,
+    #[error("Failed to parse json")]
+    InvalidUuidError(#[source] uuid::Error),
+    #[error("Failed to create presentation submission")]
+    PresentationSubmissionError(#[source] anyhow::Error),
+    #[error("Failed to parse DID")]
+    DidParseError,
+    #[error("Invalid credential format")]
+    InvalidCredentialFormatError,
+    #[error("Failed to build verifiable presentation")]
+    PresentationBuilderError(#[source] identity_credential::error::Error),
+    #[error("Failed to retrieve credential offer from the credential issuer")]
+    GetCredentialOfferError(#[source] anyhow::Error),
+    #[error("Failed to retrieve the credential issuer's authorization server metadata")]
+    GetAuthorizationServerMetadataError(#[source] anyhow::Error),
+    #[error("Failed to retrieve the credential issuer's metadata")]
+    GetCredentialIssuerMetadataError(#[source] anyhow::Error),
+    #[error("Failed to retrieve an access token from the credential issuer")]
+    GetAccessTokenError(#[source] anyhow::Error),
+    #[error("Failed to retrieve credential from the credential issuer")]
+    GetCredentialError(#[source] anyhow::Error),
+    #[error("Failed to retrieve batch credentials from the credential issuer")]
+    GetBatchCredentialError(#[source] anyhow::Error),
+    #[error("Failed to find credential offer `{0}` in the credential issuer's metadata")]
+    MissingCredentialOfferError(String),
+    #[error("Invalid offer indices")]
+    InvalidOfferIndicesError(#[source] serde_json::Error),
+    #[error("No `{0}` found in the state")]
+    MissingStateParameterError(&'static str),
+    #[error("Failed to load stronghold")]
+    StrongholdLoadingError(#[source] anyhow::Error),
+    #[error("Failed to delete credential from stronghold")]
+    StrongholdDeletionError(#[source] anyhow::Error),
+    #[error("Failed to insert credential into stronghold")]
+    StrongholdInsertionError(#[source] anyhow::Error),
+    #[error("Error while loading credentials from stronghold")]
+    StrongholdValuesError(#[source] anyhow::Error),
+}
+
+impl std::fmt::Debug for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", self)?;
+        if let Some(source) = self.source() {
+            writeln!(f, "Caused by:\n\t{}", source)?;
+        }
+        Ok(())
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod command;
 pub mod crypto;
+pub mod error;
 pub mod state;
 pub mod verifiable_credential_record;
 

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -3,6 +3,7 @@ pub mod persistence;
 pub mod reducers;
 pub mod user_prompt;
 
+use self::reducers::authorization::ConnectionRequest;
 use crate::{
     crypto::stronghold::StrongholdManager, state::user_prompt::CurrentUserPrompt,
     verifiable_credential_record::DisplayCredential,
@@ -12,10 +13,11 @@ use oid4vc_core::Subject;
 use oid4vc_manager::ProviderManager;
 use oid4vci::Wallet;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
 use ts_rs::TS;
-
-use self::reducers::authorization::ConnectionRequest;
 
 pub struct IdentityManager {
     pub subject: Arc<dyn Subject>,
@@ -47,7 +49,8 @@ pub struct AppState {
     pub credentials: Mutex<Vec<DisplayCredential>>,
     pub current_user_prompt: Mutex<Option<CurrentUserPrompt>>,
     pub dev_mode_enabled: Mutex<bool>,
-    pub debug_messages: Mutex<Vec<String>>,
+    #[ts(type = "Array<string>")]
+    pub debug_messages: Mutex<VecDeque<String>>,
     #[ts(type = "object | null")]
     pub user_journey: Mutex<Option<serde_json::Value>>,
     pub connections: Mutex<Vec<Connection>>,
@@ -105,7 +108,7 @@ mod tests {
             current_user_prompt: Mutex::new(Some(CurrentUserPrompt::Redirect {
                 target: "me".to_string(),
             })),
-            debug_messages: Mutex::new(vec![]),
+            debug_messages: Mutex::new(Default::default()),
             user_journey: Mutex::new(None),
             connections: Mutex::new(vec![]),
             ..Default::default()

--- a/src-tauri/src/state/reducers/authorization.rs
+++ b/src-tauri/src/state/reducers/authorization.rs
@@ -40,7 +40,7 @@ pub async fn read_authorization_request(state: &AppState, action: Action) -> Res
 
     if let Result::Ok(siopv2_authorization_request) = provider_manager
         .validate_request::<SIOPv2>(serde_json::from_value(payload.clone()).map_err(|source| {
-            OID4VCProviderManagerError {
+            OID4VCAuthorizationRequestError {
                 extension: "SIOPv2",
                 source,
             }
@@ -81,7 +81,7 @@ pub async fn read_authorization_request(state: &AppState, action: Action) -> Res
             });
     } else if let Result::Ok(oid4vp_authorization_request) = provider_manager
         .validate_request::<OID4VP>(serde_json::from_value(payload.clone()).map_err(|source| {
-            OID4VCProviderManagerError {
+            OID4VCAuthorizationRequestError {
                 extension: "OID4VP",
                 source,
             }

--- a/src-tauri/src/state/reducers/authorization.rs
+++ b/src-tauri/src/state/reducers/authorization.rs
@@ -167,12 +167,6 @@ pub async fn handle_siopv2_authorization_request(state: &AppState, _action: Acti
 
     if provider_manager.send_response(&response).await.is_err() {
         info!("failed to send response");
-
-        state
-            .active_connection_request
-            .lock()
-            .unwrap()
-            .replace(ConnectionRequest::SIOPv2(siopv2_authorization_request));
         return Err(SendAuthorizationResponseError);
     }
     info!("response successfully sent");
@@ -314,11 +308,6 @@ pub async fn handle_oid4vp_authorization_request(state: &AppState, action: Actio
 
     if provider_manager.send_response(&response).await.is_err() {
         info!("failed to send response");
-        state
-            .active_connection_request
-            .lock()
-            .unwrap()
-            .replace(ConnectionRequest::OID4VP(oid4vp_authorization_request));
         return Err(SendAuthorizationResponseError);
     }
     info!("response successfully sent");

--- a/src-tauri/src/state/reducers/authorization.rs
+++ b/src-tauri/src/state/reducers/authorization.rs
@@ -1,9 +1,10 @@
 use crate::{
+    error::AppError::{self, *},
     get_unverified_jwt_claims,
     state::{actions::Action, user_prompt::CurrentUserPrompt, AppState, Connection},
 };
 use identity_credential::{credential::Jwt, presentation::Presentation};
-use log::{info, warn};
+use log::info;
 use oid4vc_core::authorization_request::AuthorizationRequestObject;
 use oid4vc_manager::managers::presentation::create_presentation_submission;
 use oid4vci::credential_format_profiles::{
@@ -19,42 +20,38 @@ pub enum ConnectionRequest {
 }
 
 // Reads the request url from the payload and validates it.
-pub async fn read_authorization_request(state: &AppState, action: Action) -> anyhow::Result<()> {
+pub async fn read_authorization_request(state: &AppState, action: Action) -> Result<(), AppError> {
     info!("read_authorization_request");
 
     let state_guard = state.managers.lock().await;
     let provider_manager = &state_guard
         .identity_manager
         .as_ref()
-        .ok_or(anyhow::anyhow!("no identity manager found"))?
+        .ok_or(MissingManagerError("identity"))?
         .provider_manager;
     let stronghold_manager = state_guard
         .stronghold_manager
         .as_ref()
-        .ok_or(anyhow::anyhow!("no stronghold manager found"))?;
+        .ok_or(MissingManagerError("stronghold"))?;
 
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
+    let payload = action.payload.ok_or(MissingPayloadError)?;
 
     info!("trying to validate request: {:?}", payload);
 
     if let Result::Ok(siopv2_authorization_request) = provider_manager
-        .validate_request::<SIOPv2>(serde_json::from_value(payload.clone()).map_err(|err| {
-            let message = format!("SIOPv2 authorization request cannot be validated: {err:?}");
-            warn!("{message}");
-            state.debug_messages.lock().unwrap().push(message);
-            err
+        .validate_request::<SIOPv2>(serde_json::from_value(payload.clone()).map_err(|source| {
+            OID4VCProviderManagerError {
+                extension: "SIOPv2",
+                source,
+            }
         })?)
         .await
     {
         let redirect_uri = siopv2_authorization_request.redirect_uri.to_string();
 
         let (client_name, logo_uri, connection_url) =
-            get_siopv2_client_name_and_logo_uri(&siopv2_authorization_request).map_err(|err| {
-                let message = format!("Unable to obtain the `client_name` from the authorization request: {err:?}");
-                warn!("{message}");
-                state.debug_messages.lock().unwrap().push(message);
-                err
-            })?;
+            get_siopv2_client_name_and_logo_uri(&siopv2_authorization_request)
+                .map_err(|_| MissingAuthorizationRequestParameterError("client_name"))?;
 
         let previously_connected = state
             .connections
@@ -83,15 +80,15 @@ pub async fn read_authorization_request(state: &AppState, action: Action) -> any
                 previously_connected,
             });
     } else if let Result::Ok(oid4vp_authorization_request) = provider_manager
-        .validate_request::<OID4VP>(serde_json::from_value(payload.clone()).map_err(|err| {
-            let message = format!("OID4VP authorization request cannot be validated: {err:?}");
-            warn!("{message}");
-            state.debug_messages.lock().unwrap().push(message);
-            err
+        .validate_request::<OID4VP>(serde_json::from_value(payload.clone()).map_err(|source| {
+            OID4VCProviderManagerError {
+                extension: "OID4VP",
+                source,
+            }
         })?)
         .await
     {
-        let verifiable_credentials = stronghold_manager.values()?.unwrap();
+        let verifiable_credentials = stronghold_manager.values().map_err(StrongholdValuesError)?.unwrap();
         info!("verifiable credentials: {:?}", verifiable_credentials);
 
         let uuids: Vec<String> = oid4vp_authorization_request
@@ -107,19 +104,14 @@ pub async fn read_authorization_request(state: &AppState, action: Action) -> any
                         evaluate_input(input_descriptor, &get_unverified_jwt_claims(jwt))
                             .then_some(verifiable_credential_record.display_credential.id.clone())
                     })
-                    .ok_or(anyhow::anyhow!("unable to get credential"))
+                    .ok_or(NoMatchingCredentialError)
             })
-            .collect::<anyhow::Result<Vec<String>>>()?;
+            .collect::<Result<Vec<String>, AppError>>()?;
 
         info!("uuids of VCs that can fulfill the request: {:?}", uuids);
 
-        let (client_name, logo_uri, _) =
-            get_oid4vp_client_name_and_logo_uri(&oid4vp_authorization_request).map_err(|err| {
-                let message = format!("Unable to obtain the `client_name` from the authorization request: {err:?}");
-                warn!("{message}");
-                state.debug_messages.lock().unwrap().push(message);
-                err
-            })?;
+        let (client_name, logo_uri, _) = get_oid4vp_client_name_and_logo_uri(&oid4vp_authorization_request)
+            .map_err(|_| MissingAuthorizationRequestParameterError("client_name"))?;
 
         info!("client_name in credential_offer: {:?}", client_name);
         info!("logo_uri in read_authorization_request: {:?}", logo_uri);
@@ -139,19 +131,19 @@ pub async fn read_authorization_request(state: &AppState, action: Action) -> any
             });
         }
     } else {
-        return Err(anyhow::anyhow!("unable to validate authorization request"));
+        return Err(InvalidAuthorizationRequest(payload));
     };
 
     Ok(())
 }
 
 // Sends the authorization response.
-pub async fn handle_siopv2_authorization_request(state: &AppState, _action: Action) -> anyhow::Result<()> {
+pub async fn handle_siopv2_authorization_request(state: &AppState, _action: Action) -> Result<(), AppError> {
     let state_guard = state.managers.lock().await;
     let provider_manager = &state_guard
         .identity_manager
         .as_ref()
-        .ok_or(anyhow::anyhow!("no identity manager found"))?
+        .ok_or(MissingManagerError("identity"))?
         .provider_manager;
 
     let active_connection_request = state
@@ -159,7 +151,7 @@ pub async fn handle_siopv2_authorization_request(state: &AppState, _action: Acti
         .lock()
         .unwrap()
         .take()
-        .ok_or(anyhow::anyhow!("no active connection request found"))?;
+        .ok_or(MissingStateParameterError("active connection request"))?;
 
     let siopv2_authorization_request = match active_connection_request {
         ConnectionRequest::SIOPv2(siopv2_authorization_request) => siopv2_authorization_request,
@@ -168,7 +160,9 @@ pub async fn handle_siopv2_authorization_request(state: &AppState, _action: Acti
 
     info!("generating response");
 
-    let response = provider_manager.generate_response(&siopv2_authorization_request, Default::default())?;
+    let response = provider_manager
+        .generate_response(&siopv2_authorization_request, Default::default())
+        .map_err(GenerateAuthorizationResponseError)?;
     info!("response generated: {:?}", response);
 
     if provider_manager.send_response(&response).await.is_err() {
@@ -179,13 +173,14 @@ pub async fn handle_siopv2_authorization_request(state: &AppState, _action: Acti
             .lock()
             .unwrap()
             .replace(ConnectionRequest::SIOPv2(siopv2_authorization_request));
-        return Err(anyhow::anyhow!("failed to send response"));
+        return Err(SendAuthorizationResponseError);
     }
     info!("response successfully sent");
 
     let connection_time = chrono::Utc::now().to_rfc3339();
 
-    let (client_name, logo_uri, connection_url) = get_siopv2_client_name_and_logo_uri(&siopv2_authorization_request)?;
+    let (client_name, logo_uri, connection_url) = get_siopv2_client_name_and_logo_uri(&siopv2_authorization_request)
+        .map_err(|_| MissingAuthorizationRequestParameterError("connection_url"))?;
 
     let result = state
         .connections
@@ -220,33 +215,34 @@ pub async fn handle_siopv2_authorization_request(state: &AppState, _action: Acti
 }
 
 // Sends the authorization response including the verifiable credentials.
-pub async fn handle_oid4vp_authorization_request(state: &AppState, action: Action) -> anyhow::Result<()> {
+pub async fn handle_oid4vp_authorization_request(state: &AppState, action: Action) -> Result<(), AppError> {
     info!("handle_presentation_request");
 
     let state_guard = state.managers.lock().await;
     let stronghold_manager = state_guard
         .stronghold_manager
         .as_ref()
-        .ok_or(anyhow::anyhow!("no stronghold manager found"))?;
+        .ok_or(MissingManagerError("stronghold"))?;
     let provider_manager = &state_guard
         .identity_manager
         .as_ref()
-        .ok_or(anyhow::anyhow!("no identity manager found"))?
+        .ok_or(MissingManagerError("identity"))?
         .provider_manager;
 
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
+    let payload = action.payload.ok_or(MissingPayloadError)?;
 
-    let credential_uuids: Vec<Uuid> = serde_json::from_value::<Vec<String>>(payload["credential_uuids"].clone())?
+    let credential_uuids: Vec<Uuid> = serde_json::from_value::<Vec<String>>(payload["credential_uuids"].clone())
+        .map_err(|_| MissingPayloadValueError("credential_uuids"))?
         .into_iter()
-        .map(|index| index.parse().map_err(|_| anyhow::anyhow!("unable to parse uuid")))
-        .collect::<anyhow::Result<Vec<_>>>()?;
+        .map(|index| index.parse().map_err(InvalidUuidError))
+        .collect::<Result<Vec<_>, AppError>>()?;
 
     let active_connection_request = state
         .active_connection_request
         .lock()
         .unwrap()
         .take()
-        .ok_or(anyhow::anyhow!("no active connection request found"))?;
+        .ok_or(MissingStateParameterError("active connection request"))?;
 
     let oid4vp_authorization_request = match active_connection_request {
         ConnectionRequest::OID4VP(oid4vp_authorization_request) => oid4vp_authorization_request,
@@ -254,7 +250,8 @@ pub async fn handle_oid4vp_authorization_request(state: &AppState, action: Actio
     };
 
     let verifiable_credentials: Vec<Credential<JwtVcJson>> = stronghold_manager
-        .values()?
+        .values()
+        .map_err(StrongholdValuesError)?
         .unwrap()
         .iter()
         .filter_map(
@@ -273,7 +270,8 @@ pub async fn handle_oid4vp_authorization_request(state: &AppState, action: Actio
             .iter()
             .map(|vc| get_unverified_jwt_claims(&vc.credential))
             .collect(),
-    )?;
+    )
+    .map_err(PresentationSubmissionError)?;
 
     info!("get the subject did");
 
@@ -282,33 +280,36 @@ pub async fn handle_oid4vp_authorization_request(state: &AppState, action: Actio
         .lock()
         .unwrap()
         .as_ref()
-        .ok_or(anyhow::anyhow!("no active profile found"))?
+        .ok_or(MissingStateParameterError("active profile"))?
         .primary_did
         .clone();
 
-    let mut presentation_builder = Presentation::builder(subject_did.parse()?, Default::default());
+    let mut presentation_builder =
+        Presentation::builder(subject_did.parse().map_err(|_| DidParseError)?, Default::default());
     for verifiable_credential in verifiable_credentials {
         presentation_builder = presentation_builder.credential(Jwt::from(
             verifiable_credential
                 .credential
                 .as_str()
-                .ok_or(anyhow::anyhow!("unable to get credential"))?
+                .ok_or(InvalidCredentialFormatError)?
                 .to_string(),
         ));
     }
 
-    let verifiable_presentation = presentation_builder.build()?;
+    let verifiable_presentation = presentation_builder.build().map_err(PresentationBuilderError)?;
 
     info!("get the provider_manager");
 
     info!("generating response");
-    let response = provider_manager.generate_response(
-        &oid4vp_authorization_request,
-        OID4VPUserClaims {
-            verifiable_presentation,
-            presentation_submission,
-        },
-    )?;
+    let response = provider_manager
+        .generate_response(
+            &oid4vp_authorization_request,
+            OID4VPUserClaims {
+                verifiable_presentation,
+                presentation_submission,
+            },
+        )
+        .map_err(GenerateAuthorizationResponseError)?;
     info!("response generated: {:?}", response);
 
     if provider_manager.send_response(&response).await.is_err() {
@@ -318,13 +319,14 @@ pub async fn handle_oid4vp_authorization_request(state: &AppState, action: Actio
             .lock()
             .unwrap()
             .replace(ConnectionRequest::OID4VP(oid4vp_authorization_request));
-        return Err(anyhow::anyhow!("failed to send response"));
+        return Err(SendAuthorizationResponseError);
     }
     info!("response successfully sent");
 
     let connection_time = chrono::Utc::now().to_rfc3339();
 
-    let (client_name, logo_uri, connection_url) = get_oid4vp_client_name_and_logo_uri(&oid4vp_authorization_request)?;
+    let (client_name, logo_uri, connection_url) = get_oid4vp_client_name_and_logo_uri(&oid4vp_authorization_request)
+        .map_err(|_| MissingAuthorizationRequestParameterError("connection_url"))?;
 
     let result = state
         .connections

--- a/src-tauri/src/state/reducers/dev_mode.rs
+++ b/src-tauri/src/state/reducers/dev_mode.rs
@@ -42,7 +42,7 @@ pub async fn set_dev_mode(state: &AppState, action: Action) -> anyhow::Result<()
 pub async fn load_dev_profile(state: &AppState, _action: Action) -> Result<(), AppError> {
     info!("load dev profile");
 
-    let stronghold_manager = StrongholdManager::create("sup3rSecr3t")?;
+    let stronghold_manager = StrongholdManager::create("sup3rSecr3t").map_err(StrongholdCreationError)?;
 
     let subject = KeySubject::from_keypair(
         generate::<Ed25519KeyPair>(Some("this-is-a-very-UNSAFE-secret-key".as_bytes())),

--- a/src-tauri/src/state/reducers/dev_mode.rs
+++ b/src-tauri/src/state/reducers/dev_mode.rs
@@ -1,4 +1,5 @@
 use crate::crypto::stronghold::StrongholdManager;
+use crate::error::AppError::{self, *};
 use crate::state::actions::Action;
 use crate::state::user_prompt::CurrentUserPrompt;
 use crate::state::{AppState, Connection, Profile};
@@ -38,7 +39,7 @@ pub async fn set_dev_mode(state: &AppState, action: Action) -> anyhow::Result<()
     Ok(())
 }
 
-pub async fn load_dev_profile(state: &AppState, _action: Action) -> anyhow::Result<()> {
+pub async fn load_dev_profile(state: &AppState, _action: Action) -> Result<(), AppError> {
     info!("load dev profile");
 
     let stronghold_manager = StrongholdManager::create("sup3rSecr3t")?;
@@ -70,7 +71,8 @@ pub async fn load_dev_profile(state: &AppState, _action: Action) -> anyhow::Resu
 
     info!("loading credentials from stronghold");
     *state.credentials.lock().unwrap() = stronghold_manager
-        .values()?
+        .values()
+        .map_err(StrongholdValuesError)?
         .unwrap()
         .into_iter()
         .map(|verifiable_credential_record| verifiable_credential_record.display_credential)

--- a/src-tauri/src/state/reducers/dev_mode.rs
+++ b/src-tauri/src/state/reducers/dev_mode.rs
@@ -27,13 +27,11 @@ lazy_static! {
         }));
 }
 
-pub async fn set_dev_mode(state: &AppState, action: Action) -> anyhow::Result<()> {
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
-    let value = payload
-        .get("enabled")
-        .ok_or(anyhow::anyhow!("unable to read enabled from json payload"))?
+pub async fn set_dev_mode(state: &AppState, action: Action) -> Result<(), AppError> {
+    let payload = action.payload.ok_or(MissingPayloadError)?;
+    let value = payload["enabled"]
         .as_bool()
-        .ok_or(anyhow::anyhow!("unable to read bool from json payload"))?;
+        .ok_or(MissingPayloadValueError("enabled"))?;
     *state.dev_mode_enabled.lock().unwrap() = value;
     *state.current_user_prompt.lock().unwrap() = None;
     Ok(())

--- a/src-tauri/src/state/reducers/mod.rs
+++ b/src-tauri/src/state/reducers/mod.rs
@@ -5,6 +5,7 @@ pub mod storage;
 
 use super::{IdentityManager, Locale};
 use crate::crypto::stronghold::StrongholdManager;
+use crate::error::AppError::{self, *};
 use crate::state::actions::Action;
 use crate::state::user_prompt::CurrentUserPrompt;
 use crate::state::{AppState, Profile};
@@ -20,8 +21,8 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 /// Sets the locale to the given value. If the locale is not supported yet, the current locale will stay unchanged.
-pub fn set_locale(state: &AppState, action: Action) -> anyhow::Result<()> {
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
+pub fn set_locale(state: &AppState, action: Action) -> Result<(), AppError> {
+    let payload = action.payload.ok_or(MissingPayloadError)?;
     let locale = &payload["locale"];
     *state.locale.lock().unwrap() = serde_json::from_value::<Locale>(locale.clone())?;
     info!("locale set to: `{}`", locale);
@@ -29,23 +30,17 @@ pub fn set_locale(state: &AppState, action: Action) -> anyhow::Result<()> {
 }
 
 /// Creates a new profile with a new DID (using the did:key method) and sets it as the active profile.
-pub async fn create_identity(state: &AppState, action: Action) -> anyhow::Result<()> {
+pub async fn create_identity(state: &AppState, action: Action) -> Result<(), AppError> {
     let mut state_guard = state.managers.lock().await;
     let stronghold_manager = state_guard
         .stronghold_manager
         .as_ref()
-        .ok_or(anyhow::anyhow!("no stronghold manager found"))?;
+        .ok_or(MissingManagerError("stronghold"))?;
 
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
-    let name = payload["name"]
-        .as_str()
-        .ok_or(anyhow::anyhow!("unable to read name from json payload"))?;
-    let picture = payload["picture"]
-        .as_str()
-        .ok_or(anyhow::anyhow!("unable to read picture from json payload"))?;
-    let theme = payload["theme"]
-        .as_str()
-        .ok_or(anyhow::anyhow!("unable to read theme from json payload"))?;
+    let payload = action.payload.ok_or(MissingPayloadError)?;
+    let name = payload["name"].as_str().ok_or(MissingPayloadValueError("name"))?;
+    let picture = payload["picture"].as_str().ok_or(MissingPayloadValueError("picture"))?;
+    let theme = payload["theme"].as_str().ok_or(MissingPayloadValueError("theme"))?;
 
     let public_key = stronghold_manager.get_public_key()?;
 
@@ -72,11 +67,11 @@ pub async fn create_identity(state: &AppState, action: Action) -> anyhow::Result
     Ok(())
 }
 
-pub async fn initialize_stronghold(state: &AppState, action: Action) -> anyhow::Result<()> {
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
+pub async fn initialize_stronghold(state: &AppState, action: Action) -> Result<(), AppError> {
+    let payload = action.payload.ok_or(MissingPayloadError)?;
     let password = payload["password"]
         .as_str()
-        .ok_or(anyhow::anyhow!("unable to read password from json payload"))?;
+        .ok_or(MissingPayloadValueError("password"))?;
 
     state
         .managers
@@ -90,8 +85,8 @@ pub async fn initialize_stronghold(state: &AppState, action: Action) -> anyhow::
     Ok(())
 }
 
-pub async fn update_credential_metadata(state: &AppState, action: Action) -> anyhow::Result<()> {
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
+pub async fn update_credential_metadata(state: &AppState, action: Action) -> Result<(), AppError> {
+    let payload = action.payload.ok_or(MissingPayloadError)?;
     let credential_id: Uuid = payload["id"]
         .as_str()
         .ok_or(anyhow::anyhow!("unable to read credential id from json payload"))?
@@ -101,10 +96,11 @@ pub async fn update_credential_metadata(state: &AppState, action: Action) -> any
     let stronghold_manager = state_guard
         .stronghold_manager
         .as_ref()
-        .ok_or(anyhow::anyhow!("no stronghold manager found"))?;
+        .ok_or(MissingManagerError("stronghold"))?;
 
     let mut verifiable_credential_record: VerifiableCredentialRecord = stronghold_manager
-        .values()?
+        .values()
+        .map_err(StrongholdValuesError)?
         .unwrap()
         .into_iter()
         .find(|record| record.display_credential.id == credential_id.to_string())
@@ -156,14 +152,17 @@ pub async fn update_credential_metadata(state: &AppState, action: Action) -> any
         verifiable_credential_record.display_credential.metadata
     );
 
-    stronghold_manager.insert(
-        credential_id,
-        json!(verifiable_credential_record).to_string().as_bytes().to_vec(),
-    )?;
+    stronghold_manager
+        .insert(
+            credential_id,
+            json!(verifiable_credential_record).to_string().as_bytes().to_vec(),
+        )
+        .map_err(StrongholdInsertionError)?;
     info!("credential metadata updated");
 
     *state.credentials.lock().unwrap() = stronghold_manager
-        .values()?
+        .values()
+        .map_err(StrongholdValuesError)?
         .unwrap()
         .into_iter()
         .map(|record| record.display_credential)
@@ -172,8 +171,8 @@ pub async fn update_credential_metadata(state: &AppState, action: Action) -> any
     Ok(())
 }
 
-pub fn update_profile_settings(state: &AppState, action: Action) -> anyhow::Result<()> {
-    let payload = action.payload.ok_or(anyhow::anyhow!("unable to read payload"))?;
+pub fn update_profile_settings(state: &AppState, action: Action) -> Result<(), AppError> {
+    let payload = action.payload.ok_or(MissingPayloadError)?;
 
     let theme = match payload["theme"].as_str() {
         Some(theme) => theme.to_string(),
@@ -215,7 +214,7 @@ pub fn update_profile_settings(state: &AppState, action: Action) -> anyhow::Resu
 }
 
 /// Completely resets the state to its default values.
-pub fn reset_state(state: &AppState, _action: Action) -> anyhow::Result<()> {
+pub fn reset_state(state: &AppState, _action: Action) -> Result<(), AppError> {
     *state.active_profile.lock().unwrap() = None;
     *state.locale.lock().unwrap() = Locale::default();
     state.credentials.lock().unwrap().clear();

--- a/src-tauri/src/state/reducers/storage.rs
+++ b/src-tauri/src/state/reducers/storage.rs
@@ -19,12 +19,12 @@ pub async fn unlock_storage(state: &AppState, action: Action) -> Result<(), AppE
 
     let stronghold_manager = Arc::new(StrongholdManager::load(password).map_err(StrongholdLoadingError)?);
 
-    let public_key = stronghold_manager.get_public_key()?;
+    let public_key = stronghold_manager.get_public_key().map_err(StrongholdPublicKeyError)?;
 
     let keypair = from_existing_key::<Ed25519KeyPair>(public_key.as_slice(), None);
     let subject = Arc::new(KeySubject::from_keypair(keypair, Some(stronghold_manager.clone())));
 
-    let provider_manager = ProviderManager::new([subject.clone()])?;
+    let provider_manager = ProviderManager::new([subject.clone()]).map_err(OID4VCProviderManagerError)?;
     let wallet: Wallet = Wallet::new(subject.clone());
 
     info!("loading credentials from stronghold");

--- a/src-tauri/tests/common/assert_state_update.rs
+++ b/src-tauri/tests/common/assert_state_update.rs
@@ -71,6 +71,20 @@ pub async fn assert_state_update(
             }
             assert_eq!(*locale.lock().unwrap(), *expected_locale.lock().unwrap());
             assert_eq!(*credentials.lock().unwrap(), *expected_credentials.lock().unwrap());
+
+            dbg!(debug_messages.lock().unwrap().clone());
+            debug_messages
+                .lock()
+                .unwrap()
+                .iter()
+                .zip(expected_debug_messages.lock().unwrap().iter())
+                .for_each(|(debug_message, expected_debug_message)| {
+                    assert_eq!(
+                        debug_message.split_once(' ').unwrap().1,
+                        expected_debug_message.split_once(' ').unwrap().1
+                    );
+                });
+
             assert_eq!(
                 debug_messages.lock().unwrap().len(),
                 expected_debug_messages.lock().unwrap().len()

--- a/src-tauri/tests/common/assert_state_update.rs
+++ b/src-tauri/tests/common/assert_state_update.rs
@@ -48,6 +48,7 @@ pub async fn assert_state_update(
                 locale,
                 credentials,
                 current_user_prompt,
+                debug_messages,
                 ..
             } = app.app_handle().state::<AppState>().inner();
 
@@ -56,6 +57,7 @@ pub async fn assert_state_update(
                 locale: expected_locale,
                 credentials: expected_credentials,
                 current_user_prompt: expected_current_user_prompt,
+                debug_messages: expected_debug_messages,
                 ..
             } = expected_state;
 
@@ -69,6 +71,10 @@ pub async fn assert_state_update(
             }
             assert_eq!(*locale.lock().unwrap(), *expected_locale.lock().unwrap());
             assert_eq!(*credentials.lock().unwrap(), *expected_credentials.lock().unwrap());
+            assert_eq!(
+                debug_messages.lock().unwrap().len(),
+                expected_debug_messages.lock().unwrap().len()
+            );
             assert_eq!(
                 *current_user_prompt.lock().unwrap(),
                 *expected_current_user_prompt.lock().unwrap()

--- a/src-tauri/tests/fixtures/actions/qr_scanned_invalid_payload.json
+++ b/src-tauri/tests/fixtures/actions/qr_scanned_invalid_payload.json
@@ -1,0 +1,6 @@
+{
+    "type": "[QR Code] Scanned",
+    "payload": {
+        "form_urlencoded": "invalid payload"
+    }
+}

--- a/src-tauri/tests/fixtures/actions/unlock_storage_incorrect_password.json
+++ b/src-tauri/tests/fixtures/actions/unlock_storage_incorrect_password.json
@@ -1,0 +1,6 @@
+{
+    "type": "[Storage] Unlock",
+    "payload": {
+        "password": "incorrect password"
+    }
+}

--- a/src-tauri/tests/fixtures/states/invalid_payload_error.json
+++ b/src-tauri/tests/fixtures/states/invalid_payload_error.json
@@ -6,6 +6,6 @@
         "primary_did": "did:key:z6Mkr8yRGc8hG7t26CtjSaEfWZZsEDZZ3HECsUdwVyR4NThQ"
     },
     "debug_messages": [
-        "placeholder"
+        "[2023-11-14][22:03:55] Unable to parse QR code with content: `invalid payload`\n"
     ]
 }

--- a/src-tauri/tests/fixtures/states/invalid_payload_error.json
+++ b/src-tauri/tests/fixtures/states/invalid_payload_error.json
@@ -1,0 +1,11 @@
+{
+    "active_profile": {
+        "name": "Ferris",
+        "picture": "&#129408",
+        "theme": "system",
+        "primary_did": "did:key:z6Mkr8yRGc8hG7t26CtjSaEfWZZsEDZZ3HECsUdwVyR4NThQ"
+    },
+    "debug_messages": [
+        "placeholder"
+    ]
+}

--- a/src-tauri/tests/fixtures/states/password_required_incorrect_password_error.json
+++ b/src-tauri/tests/fixtures/states/password_required_incorrect_password_error.json
@@ -9,6 +9,6 @@
         "type": "password-required"
     },
     "debug_messages": [
-        "placeholder"
+        "[2023-11-14][22:03:55] Failed to load stronghold\nCaused by:\n\tinner error occurred(invalid file failed to decode/decrypt age content BadFileKey)\n"
     ]
 }

--- a/src-tauri/tests/fixtures/states/password_required_incorrect_password_error.json
+++ b/src-tauri/tests/fixtures/states/password_required_incorrect_password_error.json
@@ -1,0 +1,14 @@
+{
+    "active_profile": {
+        "name": "Ferris Crabman",
+        "picture": "&#129408",
+        "theme": "system",
+        "primary_did": "did:example:placeholder"
+    },
+    "current_user_prompt": {
+        "type": "password-required"
+    },
+    "debug_messages": [
+        "placeholder"
+    ]
+}

--- a/src-tauri/tests/tests/get_state.rs
+++ b/src-tauri/tests/tests/get_state.rs
@@ -10,7 +10,7 @@ async fn test_get_state_create_new() {
     setup_state_file();
     setup_stronghold();
 
-    // Deserializing the Transferstates and Actions from the accompanying json files.
+    // Deserializing the AppStates and Actions from the accompanying json files.
     let state1 = json_example::<AppState>("tests/fixtures/states/no_profile_redirect_welcome.json");
     let state2 = json_example::<AppState>("tests/fixtures/states/redirect_me.json");
     let action1 = json_example::<Action>("tests/fixtures/actions/get_state.json");
@@ -39,11 +39,49 @@ async fn test_get_state_unlock_storage() {
     setup_state_file();
     setup_stronghold();
 
-    // Deserializing the Transferstates and Actions from the accompanying json files.
+    // Deserializing the Appstates and Actions from the accompanying json files.
     let state1 = json_example::<AppState>("tests/fixtures/states/password_required.json");
     let state2 = json_example::<AppState>("tests/fixtures/states/redirect_me.json");
     let action1 = json_example::<Action>("tests/fixtures/actions/get_state.json");
     let action2 = json_example::<Action>("tests/fixtures/actions/unlock_storage.json");
+    assert_state_update(
+        // Initial state.
+        AppState {
+            managers: test_managers(vec![]),
+            active_profile: Mutex::new(Some(Profile {
+                name: "Ferris Crabman".to_string(),
+                picture: Some("&#129408".to_string()),
+                theme: Some("system".to_string()),
+                primary_did: "did:example:placeholder".to_string(),
+            })),
+            ..AppState::default()
+        },
+        vec![
+            // Get the initial state.
+            action1, // Unlock the storage.
+            action2,
+        ],
+        vec![
+            // The storage is locked, so the user is prompted to unlock it.
+            Some(state1),
+            // The storage is unlocked, so the user is redirected to the profile page.
+            Some(state2),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_get_state_unlock_storage_invalid_password() {
+    setup_state_file();
+    setup_stronghold();
+
+    // Deserializing the Appstates and Actions from the accompanying json files.
+    let state1 = json_example::<AppState>("tests/fixtures/states/password_required.json");
+    let state2 = json_example::<AppState>("tests/fixtures/states/password_required_incorrect_password_error.json");
+    let action1 = json_example::<Action>("tests/fixtures/actions/get_state.json");
+    let action2 = json_example::<Action>("tests/fixtures/actions/unlock_storage_incorrect_password.json");
     assert_state_update(
         // Initial state.
         AppState {

--- a/src-tauri/tests/tests/get_state.rs
+++ b/src-tauri/tests/tests/get_state.rs
@@ -102,7 +102,7 @@ async fn test_get_state_unlock_storage_invalid_password() {
         vec![
             // The storage is locked, so the user is prompted to unlock it.
             Some(state1),
-            // The storage is unlocked, so the user is redirected to the profile page.
+            // An incorrect password error is added to the state.
             Some(state2),
         ],
     )

--- a/src-tauri/tests/tests/load_dev_profile.rs
+++ b/src-tauri/tests/tests/load_dev_profile.rs
@@ -8,7 +8,7 @@ async fn test_load_dev_profile() {
     setup_state_file();
     setup_stronghold();
 
-    // Deserializing the Transferstates and Actions from the accompanying json files.
+    // Deserializing the Appstates and Actions from the accompanying json files.
     let state = json_example::<AppState>("tests/fixtures/states/two_credentials_redirect_me.json");
     let action = json_example::<Action>("tests/fixtures/actions/dev_load_profile.json");
     assert_state_update(AppState::default(), vec![action], vec![Some(state)]).await;
@@ -20,7 +20,7 @@ async fn test_load_dev_profile_twice() {
     setup_state_file();
     setup_stronghold();
 
-    // Deserializing the Transferstates and Actions from the accompanying json files.
+    // Deserializing the Appstates and Actions from the accompanying json files.
     let state1 = json_example::<AppState>("tests/fixtures/states/two_credentials_redirect_me.json");
     let state2 = json_example::<AppState>("tests/fixtures/states/two_credentials_redirect_me.json");
     let action = json_example::<Action>("tests/fixtures/actions/dev_load_profile.json");

--- a/src-tauri/tests/tests/qr_code_scanned.rs
+++ b/src-tauri/tests/tests/qr_code_scanned.rs
@@ -35,7 +35,7 @@ async fn test_qr_code_scanned_read_credential_offer() {
             .unwrap(),
     });
 
-    // Deserializing the Transferstates and Actions from the accompanying json files.
+    // Deserializing the Appstates and Actions from the accompanying json files.
     let state = json_example::<AppState>("tests/fixtures/states/credential_offer.json");
     let action = json_example::<Action>("tests/fixtures/actions/qr_scanned_openid_cred.json");
     assert_state_update(
@@ -75,7 +75,7 @@ async fn test_qr_code_scanned_handle_siopv2_authorization_request() {
             .unwrap(),
     });
 
-    // Deserializing the Transferstates and Actions from the accompanying json files.
+    // Deserializing the Appstates and Actions from the accompanying json files.
     let state1 = json_example::<AppState>("tests/fixtures/states/accept_connection.json");
     let state2 = json_example::<AppState>("tests/fixtures/states/did_redirect_me.json");
     let action1 = json_example::<Action>("tests/fixtures/actions/qr_scanned_id_token.json");
@@ -124,7 +124,7 @@ async fn test_qr_code_scanned_handle_oid4vp_authorization_request() {
             .unwrap(),
     });
 
-    // Deserializing the Transferstates and Actions from the accompanying json files.
+    // Deserializing the Appstates and Actions from the accompanying json files.
     let state1 = json_example::<AppState>("tests/fixtures/states/credential_share_credential.json");
     let state2 = json_example::<AppState>("tests/fixtures/states/credential_redirect_me.json");
     let action1 = json_example::<Action>("tests/fixtures/actions/qr_scanned_vp_token.json");
@@ -141,6 +141,46 @@ async fn test_qr_code_scanned_handle_oid4vp_authorization_request() {
         vec![action1, action2],
         // The state is updated with a new user prompt containing the uuid's of the candidate verifiable credentials.
         vec![Some(state1), Some(state2)],
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_qr_code_scanned_invalid_qr_code_error() {
+    setup_state_file();
+    setup_stronghold();
+
+    let managers = test_managers(vec![]);
+    let active_profile = Some(Profile {
+        name: "Ferris".to_string(),
+        picture: Some("&#129408".to_string()),
+        theme: Some("system".to_string()),
+        primary_did: managers
+            .lock()
+            .await
+            .identity_manager
+            .as_ref()
+            .unwrap()
+            .subject
+            .identifier()
+            .unwrap(),
+    });
+
+    // Deserializing the Appstates and Actions from the accompanying json files.
+    let state = json_example::<AppState>("tests/fixtures/states/invalid_payload_error.json");
+    let action = json_example::<Action>("tests/fixtures/actions/qr_scanned_invalid_payload.json");
+    assert_state_update(
+        // Initial state.
+        AppState {
+            active_profile: Mutex::new(active_profile.clone()),
+            managers,
+            ..AppState::default()
+        },
+        // A QR code is scanned containing an invalid payload.
+        vec![action],
+        // The state is updated with a new user prompt containing the credential offer.
+        vec![Some(state)],
     )
     .await;
 }

--- a/src-tauri/tests/tests/qr_code_scanned.rs
+++ b/src-tauri/tests/tests/qr_code_scanned.rs
@@ -179,7 +179,7 @@ async fn test_qr_code_scanned_invalid_qr_code_error() {
         },
         // A QR code is scanned containing an invalid payload.
         vec![action],
-        // The state is updated with a new user prompt containing the credential offer.
+        // An invalid payload error is added to the state.
         vec![Some(state)],
     )
     .await;


### PR DESCRIPTION
# Description of change
Adds initial error handling by introducing `AppError` using the thiserror crate.

This PR also applies some slight refactoring of `handle_action_inner` by removing all occurrences of `save_state` and moving it to `handle_action`, which makes the code a bit cleaner. 

Instead of all the different occurrences of `save_state` we can just 'save' an unaltered copy of the app_state like so:
```rust
    // Keep a copy of the state before it is altered, so that we can revert to it if the state update fails.
    let unaltered_state = app_state.clone();
```
If `handle_action_inner` returns an `Ok(())`, then we know the state was successfully updated and thus we know we want to save the updated state (and emit it to the frontend).

Else, if `handle_action_inner` returns an `AppError`, we want to discard all preliminary updates to the `AppState` that may have occurred by simply continuing with using the `unaltered_state`. However, we still want to add the Error message to the `debug_messages` before saving the 'unaltered_state` and emitting to the frontend:

```rust
        Err(error) => {
            // If the state update fails, we revert to the unaltered state and add the error to the debug messages.
            {
                let debug_messages = &mut unaltered_state.debug_messages.lock().unwrap();
                while debug_messages.len() > 1000 {
                    debug_messages.remove(0);
                }
                debug_messages.push_back(format!(
                    "{} {:?}",
                    chrono::Utc::now().format("[%Y-%m-%d][%H:%M:%S]"),
                    error
                ));
            }
            warn!("state update failed: {}", error);

            // Save and emit the unaltered state including the error message.
            save_state(&unaltered_state).await.ok();
            emit_event(window.clone(), &unaltered_state).ok();
        }
```

## Links to any relevant issues
n/a

## How the change has been tested
Two tests added:
- `test_qr_code_scanned_invalid_qr_code_error`
- `test_get_state_unlock_storage_invalid_password`

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
