### PR TITLE
refactor: removing all the mutexes from inside the `AppState` struct

### DIFF
--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -12,45 +12,46 @@ use crate::state::reducers::{
     update_profile_settings,
 };
 use crate::state::user_prompt::CurrentUserPrompt;
-use crate::state::AppState;
-use log::{info, warn};
+use crate::state::{AppState, AppStateContainer};
+use async_recursion::async_recursion;
+use log::info;
 use oid4vc_core::authorization_request::AuthorizationRequest;
 use oid4vci::credential_offer::CredentialOfferQuery;
 use serde_json::json;
 use tauri::Manager;
 
-#[async_recursion::async_recursion]
+#[async_recursion]
 pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
+    app_state: &mut AppState,
     Action { r#type, payload }: Action,
     _app_handle: tauri::AppHandle<R>,
-    app_state: &AppState,
 ) -> Result<(), AppError> {
     info!("received action `{:?}` with payload `{:?}`", r#type, payload);
 
     match r#type {
         ActionType::GetState => {
             // TODO: find a better way to populate all fields with values from json file
-            let loaded_state: AppState = load_state().await.unwrap_or_default();
+            let loaded_state = load_state().await.unwrap_or_default();
 
-            *app_state.active_profile.lock().unwrap() = loaded_state.active_profile.lock().unwrap().clone();
-            *app_state.locale.lock().unwrap() = loaded_state.locale.lock().unwrap().clone();
-            *app_state.connections.lock().unwrap() = loaded_state.connections.lock().unwrap().clone();
-            *app_state.debug_messages.lock().unwrap() = loaded_state.debug_messages.lock().unwrap().clone();
+            app_state.active_profile = loaded_state.active_profile.clone();
+            app_state.locale = loaded_state.locale.clone();
+            app_state.connections = loaded_state.connections.clone();
+            app_state.debug_messages = loaded_state.debug_messages.clone();
 
-            if app_state.active_profile.lock().unwrap().is_some() {
-                *app_state.current_user_prompt.lock().unwrap() = Some(CurrentUserPrompt::PasswordRequired);
+            if app_state.active_profile.is_some() {
+                app_state.current_user_prompt = Some(CurrentUserPrompt::PasswordRequired);
             } else {
                 // TODO: bug: if state is present, but empty, user will never be redirected to neither welcome or profile page
-                *app_state.current_user_prompt.lock().unwrap() = Some(CurrentUserPrompt::Redirect {
+                app_state.current_user_prompt = Some(CurrentUserPrompt::Redirect {
                     target: "welcome".to_string(),
                 });
             }
 
-            *app_state.dev_mode_enabled.lock().unwrap() = *loaded_state.dev_mode_enabled.lock().unwrap();
             // TODO: uncomment the following line for LOCAL DEVELOPMENT (DEV_MODE)
-            // *app_state.dev_mode_enabled.lock().unwrap() = true;
+            //app_state.dev_mode_enabled = loaded_state.dev_mode_enabled;
             Ok(())
         }
+
         ActionType::UnlockStorage => unlock_storage(app_state, Action { r#type, payload }).await,
         ActionType::Reset => {
             reset_state(app_state, Action { r#type, payload })?;
@@ -59,11 +60,12 @@ pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
         }
         ActionType::CreateNew => {
             let action = Action { r#type, payload };
+
             initialize_stronghold(app_state, action.clone()).await?;
             create_identity(app_state, action).await?;
 
             // When everything is done, we redirect the user to the "me" page
-            *app_state.current_user_prompt.lock().unwrap() = Some(CurrentUserPrompt::Redirect {
+            app_state.current_user_prompt = Some(CurrentUserPrompt::Redirect {
                 target: "me".to_string(),
             });
             Ok(())
@@ -81,22 +83,22 @@ pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
 
             if let Result::Ok(authorization_request) = form_urlencoded.parse::<AuthorizationRequest>() {
                 handle_action_inner(
+                    app_state,
                     Action {
                         r#type: ActionType::ReadRequest,
                         payload: Some(json!(authorization_request)),
                     },
                     _app_handle,
-                    app_state,
                 )
                 .await
             } else if let Result::Ok(credential_offer_query) = form_urlencoded.parse::<CredentialOfferQuery>() {
                 handle_action_inner(
+                    app_state,
                     Action {
                         r#type: ActionType::ReadCredentialOffer,
                         payload: Some(json!(credential_offer_query)),
                     },
                     _app_handle,
-                    app_state,
                 )
                 .await
             } else {
@@ -111,15 +113,11 @@ pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
         ActionType::CancelUserFlow => {
             if let Some(payload) = payload {
                 let redirect = payload["redirect"].as_str().unwrap();
-                app_state
-                    .current_user_prompt
-                    .lock()
-                    .unwrap()
-                    .replace(CurrentUserPrompt::Redirect {
-                        target: redirect.to_string(),
-                    });
+                app_state.current_user_prompt.replace(CurrentUserPrompt::Redirect {
+                    target: redirect.to_string(),
+                });
             } else {
-                app_state.current_user_prompt.lock().unwrap().take();
+                app_state.current_user_prompt.take();
             }
 
             Ok(())
@@ -132,11 +130,11 @@ pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
         ActionType::CredentialOffersSelected => send_credential_request(app_state, Action { r#type, payload }).await,
         ActionType::UpdateCredentialMetadata => {
             update_credential_metadata(app_state, Action { r#type, payload }).await?;
-            *app_state.current_user_prompt.lock().unwrap() = None;
+            app_state.current_user_prompt = None;
             Ok(())
         }
         ActionType::CancelUserJourney => {
-            *app_state.user_journey.lock().unwrap() = None;
+            app_state.user_journey = None;
             Ok(())
         }
         ActionType::Unknown => Err(UnknownActionTypeError { r#type, payload }),
@@ -149,36 +147,38 @@ pub(crate) async fn handle_action_inner<R: tauri::Runtime>(
 pub async fn handle_action<R: tauri::Runtime>(
     action: Action,
     _app_handle: tauri::AppHandle<R>,
-    app_state: tauri::State<'_, AppState>,
+    container: tauri::State<'_, AppStateContainer>,
     window: tauri::Window<R>,
 ) -> Result<(), String> {
     // Keep a copy of the state before it is altered, so that we can revert to it if the state update fails.
-    let unaltered_state = app_state.clone();
+    let mut guard = container.0.lock().await;
+    let app_state = &mut *guard;
+    //let unaltered_state = app_state.clone();
 
-    match handle_action_inner(action, _app_handle, app_state.inner()).await {
+    match handle_action_inner(app_state, action, _app_handle).await {
         Ok(()) => {
             info!("state updated successfully");
-            save_state(app_state.inner()).await.ok();
-            emit_event(window, app_state.inner()).ok();
+            save_state(app_state).await.ok();
+            emit_event(window, app_state).ok();
         }
         Err(error) => {
             // If the state update fails, we revert to the unaltered state and add the error to the debug messages.
-            {
-                let debug_messages = &mut unaltered_state.debug_messages.lock().unwrap();
-                while debug_messages.len() > 100 {
-                    debug_messages.remove(0);
-                }
-                debug_messages.push_back(format!(
-                    "{} {:?}",
-                    chrono::Utc::now().format("[%Y-%m-%d][%H:%M:%S]"),
-                    error
-                ));
-            }
-            warn!("state update failed: {}", error);
+            //{
+            //let debug_messages = &mut unaltered_state.debug_messages.lock().unwrap();
+            //while debug_messages.len() > 100 {
+            //debug_messages.remove(0);
+            //}
+            //debug_messages.push_back(format!(
+            //"{} {:?}",
+            //chrono::Utc::now().format("[%Y-%m-%d][%H:%M:%S]"),
+            //error
+            //));
+            //}
+            //warn!("state update failed: {}", error);
 
-            // Save and emit the unaltered state including the error message.
-            save_state(&unaltered_state).await.ok();
-            emit_event(window, &unaltered_state).ok();
+            //// Save and emit the unaltered state including the error message.
+            //save_state(&unaltered_state).await.ok();
+            //emit_event(window, &unaltered_state).ok();
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use fern::colors::Color;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use lazy_static::lazy_static;
 use log::{info, LevelFilter};
-use state::AppState;
+use state::AppStateContainer;
 use std::sync::Mutex;
 use tauri::Manager;
 use tauri_plugin_log::{fern::colors::ColoredLevelConfig, Target, TargetKind};
@@ -27,7 +27,7 @@ pub fn run() {
             }
             Ok(())
         })
-        .manage(AppState::default())
+        .manage(AppStateContainer(Default::default()))
         .plugin(
             tauri_plugin_log::Builder::new()
                 // .clear_targets()

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -53,6 +53,7 @@ pub struct AppState {
     pub connections: Vec<Connection>,
 }
 
+#[derive(Default)]
 pub struct AppStateContainer(pub tokio::sync::Mutex<AppState>);
 
 #[derive(Clone, Serialize, Debug, Deserialize, TS, PartialEq, Default)]

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -13,10 +13,7 @@ use oid4vc_core::Subject;
 use oid4vc_manager::ProviderManager;
 use oid4vci::Wallet;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::VecDeque,
-    sync::{Arc, Mutex},
-};
+use std::{collections::VecDeque, sync::Arc};
 use ts_rs::TS;
 
 pub struct IdentityManager {
@@ -41,20 +38,22 @@ pub struct AppState {
     #[serde(skip)]
     #[derivative(Debug = "ignore")]
     pub managers: tauri::async_runtime::Mutex<Managers>,
-    pub active_profile: Mutex<Option<Profile>>,
+    pub active_profile: Option<Profile>,
     #[serde(skip)]
     #[derivative(Debug = "ignore")]
-    pub active_connection_request: Mutex<Option<ConnectionRequest>>,
-    pub locale: Mutex<Locale>,
-    pub credentials: Mutex<Vec<DisplayCredential>>,
-    pub current_user_prompt: Mutex<Option<CurrentUserPrompt>>,
-    pub dev_mode_enabled: Mutex<bool>,
+    pub active_connection_request: Option<ConnectionRequest>,
+    pub locale: Locale,
+    pub credentials: Vec<DisplayCredential>,
+    pub current_user_prompt: Option<CurrentUserPrompt>,
+    pub dev_mode_enabled: bool,
     #[ts(type = "Array<string>")]
-    pub debug_messages: Mutex<VecDeque<String>>,
+    pub debug_messages: VecDeque<String>,
     #[ts(type = "object | null")]
-    pub user_journey: Mutex<Option<serde_json::Value>>,
-    pub connections: Mutex<Vec<Connection>>,
+    pub user_journey: Option<serde_json::Value>,
+    pub connections: Vec<Connection>,
 }
+
+pub struct AppStateContainer(pub tokio::sync::Mutex<AppState>);
 
 #[derive(Clone, Serialize, Debug, Deserialize, TS, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
@@ -97,20 +96,20 @@ mod tests {
     #[test]
     fn test_app_state_serialize() {
         let state = AppState {
-            active_profile: Mutex::new(Some(Profile {
+            active_profile: Some(Profile {
                 name: "John Doe".to_string(),
                 picture: None,
                 theme: None,
                 primary_did: "did:example:123".to_string(),
-            })),
-            locale: Mutex::new(Locale::En),
-            credentials: Mutex::new(vec![]),
-            current_user_prompt: Mutex::new(Some(CurrentUserPrompt::Redirect {
+            }),
+            locale: Locale::En,
+            credentials: vec![],
+            current_user_prompt: Some(CurrentUserPrompt::Redirect {
                 target: "me".to_string(),
-            })),
-            debug_messages: Mutex::new(Default::default()),
-            user_journey: Mutex::new(None),
-            connections: Mutex::new(vec![]),
+            }),
+            debug_messages: Default::default(),
+            user_journey: None,
+            connections: vec![],
             ..Default::default()
         };
 

--- a/src-tauri/src/state/reducers/storage.rs
+++ b/src-tauri/src/state/reducers/storage.rs
@@ -9,7 +9,7 @@ use oid4vc_manager::{methods::key_method::KeySubject, ProviderManager};
 use oid4vci::Wallet;
 use std::sync::Arc;
 
-pub async fn unlock_storage(state: &AppState, action: Action) -> Result<(), AppError> {
+pub async fn unlock_storage(state: &mut AppState, action: Action) -> Result<(), AppError> {
     let mut state_guard = state.managers.lock().await;
 
     let payload = action.payload.ok_or(MissingPayloadError)?;
@@ -28,7 +28,7 @@ pub async fn unlock_storage(state: &AppState, action: Action) -> Result<(), AppE
     let wallet: Wallet = Wallet::new(subject.clone());
 
     info!("loading credentials from stronghold");
-    *state.credentials.lock().unwrap() = stronghold_manager
+    state.credentials = stronghold_manager
         .values()
         .map_err(StrongholdValuesError)?
         .unwrap()
@@ -46,13 +46,9 @@ pub async fn unlock_storage(state: &AppState, action: Action) -> Result<(), AppE
 
     info!("storage unlocked");
 
-    state
-        .current_user_prompt
-        .lock()
-        .unwrap()
-        .replace(CurrentUserPrompt::Redirect {
-            target: "me".to_string(),
-        });
+    state.current_user_prompt.replace(CurrentUserPrompt::Redirect {
+        target: "me".to_string(),
+    });
 
     Ok(())
 }

--- a/src-tauri/tests/common/assert_state_update.rs
+++ b/src-tauri/tests/common/assert_state_update.rs
@@ -1,5 +1,5 @@
 use identity_wallet::{
-    state::{actions::Action, persistence::save_state, AppState},
+    state::{actions::Action, persistence::save_state, AppState, AppStateContainer},
     STATE_FILE, STRONGHOLD,
 };
 use serde_json::json;
@@ -8,12 +8,16 @@ use tempfile::NamedTempFile;
 
 /// Asserts that the state is updated as expected after the given action is handled.
 pub async fn assert_state_update(
-    current_state: AppState,
+    current_state: AppStateContainer,
     actions: Vec<Action>,
     expected_states: Vec<Option<AppState>>,
 ) {
-    // Save the current state to the state file.
-    save_state(&current_state).await.unwrap();
+    {
+        let current_state = current_state.0.lock().await;
+
+        // Save the current state to the state file.
+        save_state(&current_state).await.unwrap();
+    }
 
     // Initialize the app with the given state and action handler.
     let app = tauri::test::mock_builder()
@@ -43,6 +47,9 @@ pub async fn assert_state_update(
 
         // Assert that the state is updated as expected.
         if let Some(expected_state) = expected_state {
+            let container = app.app_handle().state::<AppStateContainer>().inner();
+            let mut guard = container.0.lock().await;
+
             let AppState {
                 active_profile,
                 locale,
@@ -50,7 +57,7 @@ pub async fn assert_state_update(
                 current_user_prompt,
                 debug_messages,
                 ..
-            } = app.app_handle().state::<AppState>().inner();
+            } = &mut *guard;
 
             let AppState {
                 active_profile: expected_active_profile,
@@ -61,38 +68,33 @@ pub async fn assert_state_update(
                 ..
             } = expected_state;
 
-            let active_profile = active_profile.lock().unwrap().clone();
-            let expected_active_profile = expected_active_profile.lock().unwrap().clone();
+            let active_profile = active_profile.clone();
+            let expected_active_profile = expected_active_profile.clone();
+
             match (active_profile, expected_active_profile) {
                 (Some(active_profile), Some(expected_active_profile)) => {
                     assert_eq!(active_profile.name, expected_active_profile.name);
                 }
                 (active_profile, expected_active_profile) => assert_eq!(active_profile, expected_active_profile),
             }
-            assert_eq!(*locale.lock().unwrap(), *expected_locale.lock().unwrap());
-            assert_eq!(*credentials.lock().unwrap(), *expected_credentials.lock().unwrap());
 
-            dbg!(debug_messages.lock().unwrap().clone());
-            debug_messages
-                .lock()
-                .unwrap()
-                .iter()
-                .zip(expected_debug_messages.lock().unwrap().iter())
-                .for_each(|(debug_message, expected_debug_message)| {
+            assert_eq!(locale, expected_locale);
+            assert_eq!(credentials, expected_credentials);
+
+            dbg!(debug_messages.clone());
+            debug_messages.iter().zip(expected_debug_messages.iter()).for_each(
+                |(debug_message, expected_debug_message)| {
                     assert_eq!(
                         debug_message.split_once(' ').unwrap().1,
                         expected_debug_message.split_once(' ').unwrap().1
                     );
-                });
+                },
+            );
 
-            assert_eq!(
-                debug_messages.lock().unwrap().len(),
-                expected_debug_messages.lock().unwrap().len()
-            );
-            assert_eq!(
-                *current_user_prompt.lock().unwrap(),
-                *expected_current_user_prompt.lock().unwrap()
-            );
+            dbg!("curry {:?}", debug_messages.len());
+            dbg!("expected up {:?}", expected_debug_messages.len());
+            assert_eq!(debug_messages.len(), expected_debug_messages.len());
+            assert_eq!(current_user_prompt, expected_current_user_prompt);
         }
     }
 }

--- a/src-tauri/tests/tests/get_state.rs
+++ b/src-tauri/tests/tests/get_state.rs
@@ -1,8 +1,8 @@
 use crate::common::assert_state_update::{assert_state_update, setup_state_file, setup_stronghold};
 use crate::common::{json_example, test_managers};
-use identity_wallet::state::Profile;
 use identity_wallet::state::{actions::Action, AppState};
-use std::sync::Mutex;
+use identity_wallet::state::{AppStateContainer, Profile};
+use tokio::sync::Mutex;
 
 #[tokio::test]
 #[serial_test::serial]
@@ -15,9 +15,12 @@ async fn test_get_state_create_new() {
     let state2 = json_example::<AppState>("tests/fixtures/states/redirect_me.json");
     let action1 = json_example::<Action>("tests/fixtures/actions/get_state.json");
     let action2 = json_example::<Action>("tests/fixtures/actions/create_new.json");
+
+    println!("state1: {:?}", state1);
+    println!("state2: {:?}", state2);
     assert_state_update(
         // Initial state.
-        AppState::default(),
+        AppStateContainer::default(),
         vec![
             // Get the initial state.
             action1, // Create a new profile.
@@ -44,18 +47,21 @@ async fn test_get_state_unlock_storage() {
     let state2 = json_example::<AppState>("tests/fixtures/states/redirect_me.json");
     let action1 = json_example::<Action>("tests/fixtures/actions/get_state.json");
     let action2 = json_example::<Action>("tests/fixtures/actions/unlock_storage.json");
+
+    let container = AppStateContainer(Mutex::new(AppState {
+        managers: test_managers(vec![]),
+        active_profile: Some(Profile {
+            name: "Ferris Crabman".to_string(),
+            picture: Some("&#129408".to_string()),
+            theme: Some("system".to_string()),
+            primary_did: "did:example:placeholder".to_string(),
+        }),
+        ..AppState::default()
+    }));
+
     assert_state_update(
         // Initial state.
-        AppState {
-            managers: test_managers(vec![]),
-            active_profile: Mutex::new(Some(Profile {
-                name: "Ferris Crabman".to_string(),
-                picture: Some("&#129408".to_string()),
-                theme: Some("system".to_string()),
-                primary_did: "did:example:placeholder".to_string(),
-            })),
-            ..AppState::default()
-        },
+        container,
         vec![
             // Get the initial state.
             action1, // Unlock the storage.
@@ -82,18 +88,21 @@ async fn test_get_state_unlock_storage_invalid_password() {
     let state2 = json_example::<AppState>("tests/fixtures/states/password_required_incorrect_password_error.json");
     let action1 = json_example::<Action>("tests/fixtures/actions/get_state.json");
     let action2 = json_example::<Action>("tests/fixtures/actions/unlock_storage_incorrect_password.json");
+
+    let container = AppStateContainer(Mutex::new(AppState {
+        managers: test_managers(vec![]),
+        active_profile: Some(Profile {
+            name: "Ferris Crabman".to_string(),
+            picture: Some("&#129408".to_string()),
+            theme: Some("system".to_string()),
+            primary_did: "did:example:placeholder".to_string(),
+        }),
+        ..AppState::default()
+    }));
+
     assert_state_update(
         // Initial state.
-        AppState {
-            managers: test_managers(vec![]),
-            active_profile: Mutex::new(Some(Profile {
-                name: "Ferris Crabman".to_string(),
-                picture: Some("&#129408".to_string()),
-                theme: Some("system".to_string()),
-                primary_did: "did:example:placeholder".to_string(),
-            })),
-            ..AppState::default()
-        },
+        container,
         vec![
             // Get the initial state.
             action1, // Unlock the storage.

--- a/src-tauri/tests/tests/load_dev_profile.rs
+++ b/src-tauri/tests/tests/load_dev_profile.rs
@@ -1,5 +1,6 @@
 use crate::common::assert_state_update::{assert_state_update, setup_state_file, setup_stronghold};
 use crate::common::json_example;
+use identity_wallet::state::AppStateContainer;
 use identity_wallet::state::{actions::Action, AppState};
 
 #[tokio::test]
@@ -11,7 +12,7 @@ async fn test_load_dev_profile() {
     // Deserializing the Appstates and Actions from the accompanying json files.
     let state = json_example::<AppState>("tests/fixtures/states/two_credentials_redirect_me.json");
     let action = json_example::<Action>("tests/fixtures/actions/dev_load_profile.json");
-    assert_state_update(AppState::default(), vec![action], vec![Some(state)]).await;
+    assert_state_update(AppStateContainer::default(), vec![action], vec![Some(state)]).await;
 }
 
 #[tokio::test]
@@ -25,7 +26,7 @@ async fn test_load_dev_profile_twice() {
     let state2 = json_example::<AppState>("tests/fixtures/states/two_credentials_redirect_me.json");
     let action = json_example::<Action>("tests/fixtures/actions/dev_load_profile.json");
     assert_state_update(
-        AppState::default(),
+        AppStateContainer::default(),
         vec![
             // Load the profile twice.
             action.clone(),


### PR DESCRIPTION
# Description of change
The mutex is now moved up one level. so nowhere in the appstate there needs to be locking of mutexes anymore.

The unaltered_state is temporarily uncommented and just used the existing struct. But I doubt this have ever worked because the whole code was behind mutexes so I guess it would only clone the pointer the the referenced data. But we maybe need to tackle this in another PR or this was implemented somewhere and I missed in which case I will update it. @nanderstabel 

## How the change has been tested
Ran through the demo, until the main screen.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
