### PR TITLE
fix: persist issuer logo for connections, temporarily determine `connection_id` based on base64-encoded issuer name

### DIFF
--- a/identity-wallet/src/state/reducers/authorization.rs
+++ b/identity-wallet/src/state/reducers/authorization.rs
@@ -210,9 +210,11 @@ pub async fn handle_siopv2_authorization_request(state: AppState, _action: Actio
     // since we currently lack a unique identitfier to distinguish connections.
     let connection_id = base64::encode_config(&client_name, base64::URL_SAFE);
 
+    persist_asset("issuer_0", &connection_id).ok();
+
     if result.is_none() {
         connections.push(Connection {
-            id: connection_id.clone(),
+            id: connection_id,
             client_name,
             url: connection_url,
             verified: false,
@@ -220,8 +222,6 @@ pub async fn handle_siopv2_authorization_request(state: AppState, _action: Actio
             last_interacted: connection_time,
         })
     };
-
-    persist_asset("issuer_0", &connection_id).ok();
 
     drop(state_guard);
     Ok(AppState {

--- a/identity-wallet/src/state/reducers/authorization.rs
+++ b/identity-wallet/src/state/reducers/authorization.rs
@@ -73,7 +73,7 @@ pub async fn read_authorization_request(state: AppState, action: Action) -> Resu
                     "{}",
                     format!(
                         "Downloading client logo from url: {}",
-                        logo_uri.clone().unwrap().as_str()
+                        logo_uri.as_ref().unwrap().as_str()
                     )
                 );
                 if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {
@@ -130,7 +130,7 @@ pub async fn read_authorization_request(state: AppState, action: Action) -> Resu
                     "{}",
                     format!(
                         "Downloading client logo from url: {}",
-                        logo_uri.clone().unwrap().as_str()
+                        logo_uri.as_ref().unwrap().as_str()
                     )
                 );
                 if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {

--- a/identity-wallet/src/state/reducers/authorization.rs
+++ b/identity-wallet/src/state/reducers/authorization.rs
@@ -337,9 +337,14 @@ pub async fn handle_oid4vp_authorization_request(state: AppState, action: Action
                 connection.last_interacted = connection_time.clone();
             });
 
+        // TODO: This is a HORRIBLE solution to determine the connection_id by the non-unique "issuer name".
+        // It is a TEMPORARY solution and should only be used in DEMO environments,
+        // since we currently lack a unique identitfier to distinguish connections.
+        let connection_id = base64::encode_config(&client_name, base64::URL_SAFE);
+
         if result.is_none() {
             connections.push(Connection {
-                id: "TODO".to_string(),
+                id: connection_id,
                 client_name,
                 url: connection_url,
                 verified: false,

--- a/identity-wallet/src/state/reducers/authorization.rs
+++ b/identity-wallet/src/state/reducers/authorization.rs
@@ -3,13 +3,14 @@ use crate::{
     get_unverified_jwt_claims,
     state::{
         actions::{listen, Action, CredentialsSelected, QrCodeScanned},
+        persistence::persist_asset,
         user_prompt::CurrentUserPrompt,
         AppState, Connection,
     },
     utils::{download_asset, LogoType},
 };
 use identity_credential::{credential::Jwt, presentation::Presentation};
-use log::{debug, info};
+use log::{debug, info, warn};
 use oid4vc::oid4vc_core::authorization_request::{AuthorizationRequest, Object};
 use oid4vc::oid4vc_manager::managers::presentation::create_presentation_submission;
 use oid4vc::oid4vci::credential_format_profiles::{
@@ -66,6 +67,19 @@ pub async fn read_authorization_request(state: AppState, action: Action) -> Resu
 
             info!("client_name in credential_offer: {:?}", client_name);
             info!("logo_uri in read_authorization_request: {:?}", logo_uri);
+
+            if logo_uri.is_some() {
+                debug!(
+                    "{}",
+                    format!(
+                        "Downloading client logo from url: {}",
+                        logo_uri.clone().unwrap().as_str()
+                    )
+                );
+                if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {
+                    let _ = download_asset(logo_uri, LogoType::IssuerLogo, 0).await;
+                }
+            }
 
             drop(state_guard);
             return Ok(AppState {
@@ -179,16 +193,7 @@ pub async fn handle_siopv2_authorization_request(state: AppState, _action: Actio
         .map_err(|_| MissingAuthorizationRequestParameterError("connection_url"))?;
 
     if logo_uri.is_some() {
-        debug!(
-            "{}",
-            format!(
-                "Downloading issuer logo from url: {}",
-                logo_uri.clone().unwrap().as_str()
-            )
-        );
-        if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {
-            let _ = download_asset(logo_uri, LogoType::IssuerLogo, 0).await;
-        }
+        warn!("Skipping download of client logo as it should have already been downloaded in `read_authorization_request()` and be present in /assets/tmp folder");
     }
 
     let mut connections = state.connections.clone();
@@ -200,9 +205,14 @@ pub async fn handle_siopv2_authorization_request(state: AppState, _action: Actio
             connection.last_interacted = connection_time.clone();
         });
 
+    // TODO: This is a HORRIBLE solution to determine the connection_id by the non-unique "issuer name".
+    // It is a TEMPORARY solution and should only be used in DEMO environments,
+    // since we currently lack a unique identitfier to distinguish connections.
+    let connection_id = base64::encode_config(&client_name, base64::URL_SAFE);
+
     if result.is_none() {
         connections.push(Connection {
-            id: "TODO".to_string(),
+            id: connection_id.clone(),
             client_name,
             url: connection_url,
             verified: false,
@@ -210,6 +220,8 @@ pub async fn handle_siopv2_authorization_request(state: AppState, _action: Actio
             last_interacted: connection_time,
         })
     };
+
+    persist_asset("issuer_0", &connection_id).ok();
 
     drop(state_guard);
     Ok(AppState {

--- a/identity-wallet/src/state/reducers/credential_offer.rs
+++ b/identity-wallet/src/state/reducers/credential_offer.rs
@@ -183,7 +183,7 @@ pub async fn read_credential_offer(state: AppState, action: Action) -> Result<Ap
                 "{}",
                 format!(
                     "Downloading issuer logo from url: {}",
-                    logo_uri.clone().unwrap().as_str()
+                    logo_uri.as_ref().unwrap().as_str()
                 )
             );
             if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {

--- a/identity-wallet/src/state/reducers/dev_mode.rs
+++ b/identity-wallet/src/state/reducers/dev_mode.rs
@@ -192,7 +192,7 @@ async fn load_ferris_profile() -> Result<AppState, AppError> {
 
     state.connections = vec![
         Connection {
-            id: "kw1c".to_string(),
+            id: "ngdil".to_string(),
             client_name: "NGDIL Demo".to_string(),
             url: "api.ngdil-demo.tanglelabs.io".to_string(),
             verified: false,

--- a/unime/src/lib/components/atoms/Image.svelte
+++ b/unime/src/lib/components/atoms/Image.svelte
@@ -59,7 +59,7 @@ Displays an image (loaded from disk) or a fallback component.
   <img
     src={assetUrl}
     alt="img_{id}"
-    class={twMerge('max-h-full w-full overflow-hidden bg-white object-cover', $$props.imgClass)}
+    class={twMerge('max-h-full w-full overflow-hidden bg-white object-contain', $$props.imgClass)}
     on:error={() => {
       id = null;
       console.warn(`could not load image for id=[${id}]`);

--- a/unime/src/lib/connections/ConnectionSummary.svelte
+++ b/unime/src/lib/connections/ConnectionSummary.svelte
@@ -26,7 +26,7 @@
 
 <div class="flex flex-col items-center justify-center space-y-4">
   <div class="flex w-full flex-col items-center justify-center space-y-4 py-6">
-    <div class="flex h-[75px] w-[75px] items-center justify-center overflow-hidden rounded-3xl bg-white p-4">
+    <div class="flex h-[75px] w-[75px] items-center justify-center overflow-hidden rounded-3xl bg-white p-2">
       <Image
         id={connection.id}
         imgClass="h-full w-full rounded-2xl"

--- a/unime/src/lib/connections/ConnectionsList.svelte
+++ b/unime/src/lib/connections/ConnectionsList.svelte
@@ -69,7 +69,7 @@
           </Image>
         </div>
         <div slot="right" class="h-full pr-2 pt-1 text-[12px]/[20px] font-medium text-slate-400">
-          {new Date().toLocaleString($state.locale, {
+          {new Date(connection.last_interacted).toLocaleString($state.locale, {
             dateStyle: 'short',
             timeStyle: 'short',
           })}

--- a/unime/src/lib/events/History.svelte
+++ b/unime/src/lib/events/History.svelte
@@ -57,7 +57,7 @@
       {#each eventsList as event}
         <div class="flex justify-between">
           <div class="z-10 mr-3 h-6 w-6 overflow-hidden rounded-full bg-white p-0.5 ring-8 ring-silver">
-            <Image id={event.connection.id} imgClass="h-full w-full object-contain" />
+            <Image id={event.connection.id} imgClass="h-full w-full" />
           </div>
           <div class="grow">
             <HistoryEntry {...event} />

--- a/unime/src/routes/badges/[id]/+page.svelte
+++ b/unime/src/routes/badges/[id]/+page.svelte
@@ -78,7 +78,7 @@
       // base64url encode
       const connectionId = btoa(issuer_name).replace('+', '-').replace('/', '_');
       // verify that the connection exists
-      if ($state.connections.find((c) => c.id === connectionId)) {
+      if ($state.connections.some((c) => c.id === connectionId)) {
         return connectionId;
       } else {
         return null;

--- a/unime/src/routes/badges/[id]/+page.svelte
+++ b/unime/src/routes/badges/[id]/+page.svelte
@@ -165,7 +165,6 @@
             {#if credential.data.issuanceDate}
               {new Date(credential.data.issuanceDate).toLocaleString($state.locale, {
                 dateStyle: 'long',
-                // timeStyle: 'medium',
               })}
             {/if}
           </p>

--- a/unime/src/routes/prompt/accept-connection/+page.svelte
+++ b/unime/src/routes/prompt/accept-connection/+page.svelte
@@ -50,7 +50,7 @@
   <div class="flex grow flex-col items-center justify-center space-y-6 p-4">
     {#if $state.current_user_prompt.logo_uri}
       <div class="flex h-[75px] w-[75px] overflow-hidden rounded-3xl bg-white p-2 dark:bg-silver">
-        <img src={$state.current_user_prompt.logo_uri} alt="logo" />
+        <Image id={'issuer_0'} isTempAsset={true} />
       </div>
     {:else}
       <PaddedIcon icon={PlugsConnected} />

--- a/unime/src/routes/prompt/accept-connection/+page.svelte
+++ b/unime/src/routes/prompt/accept-connection/+page.svelte
@@ -37,9 +37,10 @@
 
   const hostname = new URL($state.current_user_prompt.redirect_uri).hostname;
 
-  console.log($state.current_user_prompt);
+  console.log({ '$state.current_user_prompt': $state.current_user_prompt });
 
   onDestroy(async () => {
+    // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
     dispatch({ type: '[User Flow] Cancel' });
   });
 </script>

--- a/unime/src/routes/prompt/credential-offer/+page.svelte
+++ b/unime/src/routes/prompt/credential-offer/+page.svelte
@@ -103,7 +103,7 @@
         id={'issuer_0'}
         isTempAsset={true}
         iconClass="dark:text-slate-800"
-        imgClass="flex w-full items-center justify-center overflow-hidden rounded-3xl p-2 object-contain"
+        imgClass="flex w-full items-center justify-center overflow-hidden rounded-3xl p-2"
       >
         <div slot="fallback">
           <PaddedIcon icon={DownloadSimple} />

--- a/unime/src/routes/prompt/share-credentials/+page.svelte
+++ b/unime/src/routes/prompt/share-credentials/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
+
   import { goto } from '$app/navigation';
 
   import { dispatch } from '$lib/dispatcher';
   import LL from '$src/i18n/i18n-svelte';
   import Button from '$src/lib/components/atoms/Button.svelte';
   import Checkbox from '$src/lib/components/atoms/Checkbox.svelte';
+  import Image from '$src/lib/components/atoms/Image.svelte';
   import PaddedIcon from '$src/lib/components/atoms/PaddedIcon.svelte';
   import ListItemCard from '$src/lib/components/molecules/ListItemCard.svelte';
   import TopNavBar from '$src/lib/components/molecules/navigation/TopNavBar.svelte';
@@ -18,6 +21,13 @@
   let selected_credentials = $state.credentials?.filter((c) => $state.current_user_prompt.options.indexOf(c.id) > -1);
 
   let client_name = $state.current_user_prompt.client_name;
+
+  console.log({ '$state.current_user_prompt': $state.current_user_prompt });
+
+  onDestroy(async () => {
+    // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
+    dispatch({ type: '[User Flow] Cancel' });
+  });
 </script>
 
 <div class="content-height flex flex-col items-stretch bg-silver dark:bg-navy">
@@ -27,7 +37,7 @@
     <!-- Header -->
     {#if $state.current_user_prompt.logo_uri}
       <div class="flex h-[75px] w-[75px] overflow-hidden rounded-3xl bg-white p-2 dark:bg-silver">
-        <img src={$state.current_user_prompt.logo_uri} alt="logo" />
+        <Image id={'issuer_0'} isTempAsset={true} />
       </div>
     {:else}
       <PaddedIcon icon={PlugsConnected} />

--- a/unime/src/routes/welcome/password/completed/+page.svelte
+++ b/unime/src/routes/welcome/password/completed/+page.svelte
@@ -29,7 +29,7 @@
     <div class="relative">
       <div class="relative z-10">
         <div class="text-[100px]/[100px]"><Shield class="text-primary" /></div>
-        <span class="absolute left-[calc(50%_-_22px)] top-[calc(50%_-_22px)] text-[44px]/[44px]">
+        <span class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-[44px]/[44px]">
           {@html $onboarding_state.picture ?? ''}
         </span>
       </div>


### PR DESCRIPTION
# Description of change
* persist issuer logo when connection is accepted
* since distinction between connections is still an open topic, we agreed on using the issuer name as the identifier for now (in the near future, this needs to be changed to the DID of the issuer or the (sub)domain where the connection was made to or a combination of both)

## Links to any relevant issues
n/a

## How the change has been tested
Due to the urgency of this fix, it has only been tested locally in a desktop environment

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
