### PR TITLE
fix: persist client image for OID4VP and OID4VCI flows, clear all temporary assets on canceled user flow

### DIFF
--- a/identity-wallet/src/persistence.rs
+++ b/identity-wallet/src/persistence.rs
@@ -140,7 +140,7 @@ pub fn clear_all_assets() -> Result<(), AppError> {
 /// the downloaded file needs to be further treated and moved out of the `/tmp` folder.
 ///
 /// Restrictions:
-/// - max. file size: 2MB
+/// - max. file size: 2 MB
 /// - supported file types: `.png`, `.svg`
 pub async fn download_asset(url: reqwest::Url, logo_type: LogoType, index: usize) -> Result<(), AppError> {
     let assets_dir = ASSETS_DIR.lock().unwrap().as_path().to_owned();
@@ -168,9 +168,9 @@ pub async fn download_asset(url: reqwest::Url, logo_type: LogoType, index: usize
 
     let mut content = Cursor::new(response.bytes().await?);
 
-    // Abort download if file size is bigger than 2MB
+    // Abort download if file size is bigger than 2 MB
     if content.get_ref().len() > 1_024 * 1_024 * 2 {
-        return Err(AppError::DownloadAborted("File size is bigger than 2MB"));
+        return Err(AppError::DownloadAborted("File size is bigger than 2 MB"));
     }
 
     let mut file = std::fs::File::create(tmp_dir.join(format!("{}_{}.{}", logo_type, index, file_extension)))?;

--- a/identity-wallet/src/persistence.rs
+++ b/identity-wallet/src/persistence.rs
@@ -103,8 +103,8 @@ pub async fn delete_stronghold() -> anyhow::Result<()> {
 
 #[derive(Display)]
 pub enum LogoType {
-    #[strum(serialize = "issuer")]
-    IssuerLogo,
+    #[strum(serialize = "client")]
+    ClientLogo,
     #[strum(serialize = "credential")]
     CredentialLogo,
 }

--- a/identity-wallet/src/state/common/actions/cancel_user_flow.rs
+++ b/identity-wallet/src/state/common/actions/cancel_user_flow.rs
@@ -6,7 +6,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-/// Action to cancel the user flow and redirect to a specific route.
+/// Action to cancel the user flow and (optionally) redirect to a specific route.
 #[derive(Serialize, Deserialize, Debug, TS, Clone)]
 #[ts(export, export_to = "bindings/actions/CancelUserFlow.ts")]
 pub struct CancelUserFlow {

--- a/identity-wallet/src/state/common/reducers/cancel_user_flow.rs
+++ b/identity-wallet/src/state/common/reducers/cancel_user_flow.rs
@@ -1,4 +1,5 @@
 use crate::error::AppError::{self};
+use crate::persistence::clear_assets_tmp_folder;
 use crate::state::actions::{listen, Action};
 use crate::state::common::actions::cancel_user_flow::CancelUserFlow;
 use crate::state::user_prompt::CurrentUserPrompt;
@@ -6,6 +7,7 @@ use crate::state::AppState;
 
 pub async fn cancel_user_flow(state: AppState, action: Action) -> Result<AppState, AppError> {
     if let Some(cancel_user_flow) = listen::<CancelUserFlow>(action) {
+        clear_assets_tmp_folder().ok();
         return Ok(AppState {
             current_user_prompt: cancel_user_flow
                 .redirect

--- a/identity-wallet/src/state/connections/reducers/handle_siopv2_authorization_request.rs
+++ b/identity-wallet/src/state/connections/reducers/handle_siopv2_authorization_request.rs
@@ -55,7 +55,7 @@ pub async fn handle_siopv2_authorization_request(mut state: AppState, _action: A
     let mut connections = state.connections;
     let connection = connections.update_or_insert(&connection_url, &client_name);
 
-    persist_asset("issuer_0", &connection.id).ok();
+    persist_asset("client_0", &connection.id).ok();
 
     // History
     state.history.push(HistoryEvent {

--- a/identity-wallet/src/state/credentials/reducers/handle_oid4vp_authorization_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/handle_oid4vp_authorization_request.rs
@@ -132,7 +132,7 @@ pub async fn handle_oid4vp_authorization_request(mut state: AppState, action: Ac
         let mut connections = state.connections;
         let connection = connections.update_or_insert(&connection_url, &client_name);
 
-        persist_asset("issuer_0", &connection.id).ok();
+        persist_asset("client_0", &connection.id).ok();
 
         // History
         if !previously_connected {

--- a/identity-wallet/src/state/credentials/reducers/handle_oid4vp_authorization_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/handle_oid4vp_authorization_request.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::AppError::{self, *},
+    persistence::persist_asset,
     state::{
         actions::{listen, Action},
         core_utils::{
@@ -130,6 +131,8 @@ pub async fn handle_oid4vp_authorization_request(mut state: AppState, action: Ac
         let previously_connected = state.connections.contains(connection_url.as_str(), &client_name);
         let mut connections = state.connections;
         let connection = connections.update_or_insert(&connection_url, &client_name);
+
+        persist_asset("issuer_0", &connection.id).ok();
 
         // History
         if !previously_connected {

--- a/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
@@ -204,7 +204,7 @@ pub async fn send_credential_request(mut state: AppState, action: Action) -> Res
         let mut connections = state.connections;
         let connection = connections.update_or_insert(connection_url, &issuer_name);
 
-        persist_asset("issuer_0", &connection.id).ok();
+        persist_asset("client_0", &connection.id).ok();
 
         // History
         if !history_credentials.is_empty() {

--- a/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
@@ -204,6 +204,8 @@ pub async fn send_credential_request(mut state: AppState, action: Action) -> Res
         let mut connections = state.connections;
         let connection = connections.update_or_insert(connection_url, &issuer_name);
 
+        persist_asset("issuer_0", &connection.id).ok();
+
         // History
         if !history_credentials.is_empty() {
             // Only add a `ConnectionAdded` event if the connection was not previously connected.

--- a/identity-wallet/src/state/qr_code/reducers/read_authorization_request.rs
+++ b/identity-wallet/src/state/qr_code/reducers/read_authorization_request.rs
@@ -62,7 +62,7 @@ pub async fn read_authorization_request(state: AppState, action: Action) -> Resu
                     )
                 );
                 if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {
-                    let _ = download_asset(logo_uri, LogoType::IssuerLogo, 0).await;
+                    let _ = download_asset(logo_uri, LogoType::ClientLogo, 0).await;
                 }
             }
 
@@ -123,7 +123,7 @@ pub async fn read_authorization_request(state: AppState, action: Action) -> Resu
                     )
                 );
                 if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {
-                    let _ = download_asset(logo_uri, LogoType::IssuerLogo, 0).await;
+                    let _ = download_asset(logo_uri, LogoType::ClientLogo, 0).await;
                 }
             }
 

--- a/identity-wallet/src/state/qr_code/reducers/read_credential_offer.rs
+++ b/identity-wallet/src/state/qr_code/reducers/read_credential_offer.rs
@@ -183,7 +183,7 @@ pub async fn read_credential_offer(state: AppState, action: Action) -> Result<Ap
                 )
             );
             if let Some(logo_uri) = logo_uri.as_ref().and_then(|s| s.parse::<reqwest::Url>().ok()) {
-                let _ = download_asset(logo_uri, LogoType::IssuerLogo, 0).await;
+                let _ = download_asset(logo_uri, LogoType::ClientLogo, 0).await;
             }
         }
 

--- a/unime/src-tauri/tests/tests/assets_download.rs
+++ b/unime/src-tauri/tests/tests/assets_download.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
-async fn when_size_is_less_than_2mb_then_download_should_start() {
+async fn when_size_is_less_than_2_mb_then_download_should_start() {
     let mock_server = MockServer::start().await;
 
     // generate 1MB of random bytes
@@ -27,7 +27,7 @@ async fn when_size_is_less_than_2mb_then_download_should_start() {
 }
 
 #[tokio::test]
-async fn when_size_is_bigger_than_2mb_then_download_should_fail() {
+async fn when_size_is_bigger_than_2_mb_then_download_should_fail() {
     let mock_server = MockServer::start().await;
 
     // generate 3MB of random bytes

--- a/unime/src/routes/prompt/accept-connection/+page.svelte
+++ b/unime/src/routes/prompt/accept-connection/+page.svelte
@@ -41,7 +41,7 @@
 
   onDestroy(async () => {
     // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
-    dispatch({ type: '[User Flow] Cancel' });
+    dispatch({ type: '[User Flow] Cancel', payload: { redirect: 'me' } });
   });
 </script>
 

--- a/unime/src/routes/prompt/accept-connection/+page.svelte
+++ b/unime/src/routes/prompt/accept-connection/+page.svelte
@@ -41,7 +41,7 @@
 
   onDestroy(async () => {
     // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
-    dispatch({ type: '[User Flow] Cancel' });
+    dispatch({ type: '[User Flow] Cancel', payload: {} });
   });
 </script>
 

--- a/unime/src/routes/prompt/accept-connection/+page.svelte
+++ b/unime/src/routes/prompt/accept-connection/+page.svelte
@@ -51,7 +51,7 @@
   <div class="flex grow flex-col items-center justify-center space-y-6 p-4">
     {#if $state.current_user_prompt.logo_uri}
       <div class="flex h-[75px] w-[75px] overflow-hidden rounded-3xl bg-white p-2 dark:bg-silver">
-        <Image id={'issuer_0'} isTempAsset={true} />
+        <Image id={'client_0'} isTempAsset={true} />
       </div>
     {:else}
       <PaddedIcon icon={PlugsConnected} />

--- a/unime/src/routes/prompt/accept-connection/+page.svelte
+++ b/unime/src/routes/prompt/accept-connection/+page.svelte
@@ -41,7 +41,7 @@
 
   onDestroy(async () => {
     // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
-    dispatch({ type: '[User Flow] Cancel', payload: { redirect: 'me' } });
+    dispatch({ type: '[User Flow] Cancel' });
   });
 </script>
 

--- a/unime/src/routes/prompt/credential-offer/+page.svelte
+++ b/unime/src/routes/prompt/credential-offer/+page.svelte
@@ -87,7 +87,7 @@
   });
 
   onDestroy(async () => {
-    dispatch({ type: '[User Flow] Cancel' });
+    dispatch({ type: '[User Flow] Cancel', payload: { redirect: 'me' } });
   });
 </script>
 

--- a/unime/src/routes/prompt/credential-offer/+page.svelte
+++ b/unime/src/routes/prompt/credential-offer/+page.svelte
@@ -87,7 +87,7 @@
   });
 
   onDestroy(async () => {
-    dispatch({ type: '[User Flow] Cancel', payload: { redirect: 'me' } });
+    dispatch({ type: '[User Flow] Cancel' });
   });
 </script>
 

--- a/unime/src/routes/prompt/credential-offer/+page.svelte
+++ b/unime/src/routes/prompt/credential-offer/+page.svelte
@@ -87,7 +87,7 @@
   });
 
   onDestroy(async () => {
-    dispatch({ type: '[User Flow] Cancel' });
+    dispatch({ type: '[User Flow] Cancel', payload: {} });
   });
 </script>
 

--- a/unime/src/routes/prompt/credential-offer/+page.svelte
+++ b/unime/src/routes/prompt/credential-offer/+page.svelte
@@ -71,7 +71,7 @@
   let credentialLogoUrls = {};
 
   onMount(async () => {
-    issuerLogoUrl = await getImageAsset('issuer_0', true);
+    issuerLogoUrl = await getImageAsset('client_0', true);
     // credentialLogoUrl = await getImageAsset('credential', true);
 
     // $state?.current_user_prompt?.display?.forEach(async (display, i) => {
@@ -100,7 +100,7 @@
       <!-- TODO: should fallback to <PaddedIcon> instead of icon -->
 
       <Image
-        id={'issuer_0'}
+        id={'client_0'}
         isTempAsset={true}
         iconClass="dark:text-slate-800"
         imgClass="flex w-full items-center justify-center overflow-hidden rounded-3xl p-2"

--- a/unime/src/routes/prompt/share-credentials/+page.svelte
+++ b/unime/src/routes/prompt/share-credentials/+page.svelte
@@ -26,7 +26,7 @@
 
   onDestroy(async () => {
     // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
-    dispatch({ type: '[User Flow] Cancel' });
+    dispatch({ type: '[User Flow] Cancel', payload: {} });
   });
 </script>
 

--- a/unime/src/routes/prompt/share-credentials/+page.svelte
+++ b/unime/src/routes/prompt/share-credentials/+page.svelte
@@ -37,7 +37,7 @@
     <!-- Header -->
     {#if $state.current_user_prompt.logo_uri}
       <div class="flex h-[75px] w-[75px] overflow-hidden rounded-3xl bg-white p-2 dark:bg-silver">
-        <Image id={'issuer_0'} isTempAsset={true} />
+        <Image id={'client_0'} isTempAsset={true} />
       </div>
     {:else}
       <PaddedIcon icon={PlugsConnected} />

--- a/unime/src/routes/prompt/share-credentials/+page.svelte
+++ b/unime/src/routes/prompt/share-credentials/+page.svelte
@@ -26,7 +26,7 @@
 
   onDestroy(async () => {
     // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
-    dispatch({ type: '[User Flow] Cancel', payload: { redirect: 'me' } });
+    dispatch({ type: '[User Flow] Cancel' });
   });
 </script>
 

--- a/unime/src/routes/prompt/share-credentials/+page.svelte
+++ b/unime/src/routes/prompt/share-credentials/+page.svelte
@@ -26,7 +26,7 @@
 
   onDestroy(async () => {
     // TODO: is onDestroy also called when user accepts since the component itself is destroyed?
-    dispatch({ type: '[User Flow] Cancel' });
+    dispatch({ type: '[User Flow] Cancel', payload: { redirect: 'me' } });
   });
 </script>
 


### PR DESCRIPTION
# Description of change
Persists the image asset of the client that is already downloaded correctly to the `assets/tmp` folder, but never got moved to `assets`.

## Links to any relevant issues
n/a

## How the change has been tested
Local testing on desktop app

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
