### PR TITLE
fix: prevent locale from being reset after onboarding

### DIFF
--- a/identity-wallet/src/state/profile_settings/reducers/create_new.rs
+++ b/identity-wallet/src/state/profile_settings/reducers/create_new.rs
@@ -46,7 +46,8 @@ pub async fn create_identity(mut state: AppState, action: Action) -> Result<AppS
                 theme,
                 primary_did: subject.identifier().map_err(OID4VCSubjectIdentifierError)?,
             }),
-            ..Default::default()
+            ..state.profile_settings
+            //..Default::default()
         };
 
         state_guard.identity_manager.replace(IdentityManager {

--- a/identity-wallet/src/state/profile_settings/reducers/create_new.rs
+++ b/identity-wallet/src/state/profile_settings/reducers/create_new.rs
@@ -47,7 +47,6 @@ pub async fn create_identity(mut state: AppState, action: Action) -> Result<AppS
                 primary_did: subject.identifier().map_err(OID4VCSubjectIdentifierError)?,
             }),
             ..state.profile_settings
-            //..Default::default()
         };
 
         state_guard.identity_manager.replace(IdentityManager {

--- a/unime/src-tauri/tests/common/assert_state_update.rs
+++ b/unime/src-tauri/tests/common/assert_state_update.rs
@@ -50,7 +50,7 @@ pub async fn assert_state_update(
         // Assert that the state is updated as expected.
         if let Some(expected_state) = expected_state {
             let container = app.app_handle().state::<AppStateContainer>().inner();
-            let mut guard = container.0.lock().await;
+            let guard = container.0.lock().await;
 
             let AppState {
                 connections,
@@ -62,7 +62,9 @@ pub async fn assert_state_update(
                 history,
                 extensions,
                 ..
-            } = &mut *guard;
+            } = &mut guard.clone();
+
+            drop(guard);
 
             let AppState {
                 connections: expected_connections,
@@ -75,6 +77,8 @@ pub async fn assert_state_update(
                 extensions: expected_extensions,
                 ..
             } = expected_state;
+
+            println!("Current state:\n{:#?}\n\n-------------------------------------\n\nExpected state:\n{:#?}\n", container.0.lock().await, expected_state);
 
             assert_eq!(connections, expected_connections);
 

--- a/unime/src-tauri/tests/common/assert_state_update.rs
+++ b/unime/src-tauri/tests/common/assert_state_update.rs
@@ -78,7 +78,11 @@ pub async fn assert_state_update(
                 ..
             } = expected_state;
 
-            println!("Current state:\n{:#?}\n\n-------------------------------------\n\nExpected state:\n{:#?}\n", container.0.lock().await, expected_state);
+            println!(
+                "Current state:\n{:#?}\n\n-------------------------------------\n\nExpected state:\n{:#?}\n",
+                container.0.lock().await,
+                expected_state
+            );
 
             assert_eq!(connections, expected_connections);
 

--- a/unime/src-tauri/tests/fixtures/states/nl-NL_redirect_me.json
+++ b/unime/src-tauri/tests/fixtures/states/nl-NL_redirect_me.json
@@ -1,0 +1,15 @@
+{
+  "profile_settings": {
+    "profile": {
+      "name": "Ferris Crabman",
+      "picture": "&#129408",
+      "theme": "system",
+      "primary_did": "did:example:placeholder"
+    },
+    "locale": "nl-NL"
+  },
+  "current_user_prompt": {
+    "type": "redirect",
+    "target": "me"
+  }
+}

--- a/unime/src-tauri/tests/fixtures/states/no_profile_nl-NL_redirect_welcome.json
+++ b/unime/src-tauri/tests/fixtures/states/no_profile_nl-NL_redirect_welcome.json
@@ -1,5 +1,5 @@
 {
-  "profile": {
+  "profile_settings": {
     "locale": "nl-NL"
   },
   "current_user_prompt": {

--- a/unime/src-tauri/tests/fixtures/states/no_profile_nl-NL_redirect_welcome.json
+++ b/unime/src-tauri/tests/fixtures/states/no_profile_nl-NL_redirect_welcome.json
@@ -1,0 +1,9 @@
+{
+  "profile": {
+    "locale": "nl-NL"
+  },
+  "current_user_prompt": {
+    "type": "redirect",
+    "target": "welcome"
+  }
+}

--- a/unime/src-tauri/tests/tests/get_state.rs
+++ b/unime/src-tauri/tests/tests/get_state.rs
@@ -57,7 +57,7 @@ async fn test_locale_persistency_during_onboarding() {
         container,
         vec![
             // Get the initial state.
-            action // Create a new profile.
+            action, // Create a new profile.
         ],
         vec![
             // The profile was created, so the user is redirected to the profile page.

--- a/unime/src-tauri/tests/tests/get_state.rs
+++ b/unime/src-tauri/tests/tests/get_state.rs
@@ -41,7 +41,7 @@ async fn test_get_state_create_new() {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_locale_persistency_during_onboarding() {
+async fn test_locale_stays_unchanged_on_profile_creation() {
     setup_state_file();
     setup_stronghold();
 

--- a/unime/src-tauri/tests/tests/get_state.rs
+++ b/unime/src-tauri/tests/tests/get_state.rs
@@ -41,6 +41,34 @@ async fn test_get_state_create_new() {
 
 #[tokio::test]
 #[serial_test::serial]
+async fn test_locale_persistency_during_onboarding() {
+    setup_state_file();
+    setup_stronghold();
+
+    // Deserializing the AppStates and Actions from the accompanying json files.
+    let state1 = json_example::<AppState>("tests/fixtures/states/no_profile_nl-NL_redirect_welcome.json");
+    let state2 = json_example::<AppState>("tests/fixtures/states/nl-NL_redirect_me.json");
+    let action = json_example::<Action>("tests/fixtures/actions/create_new.json");
+
+    let container = AppStateContainer(Mutex::new(state1));
+
+    assert_state_update(
+        // Initial state.
+        container,
+        vec![
+            // Get the initial state.
+            action // Create a new profile.
+        ],
+        vec![
+            // The profile was created, so the user is redirected to the profile page.
+            Some(state2),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
 async fn test_get_state_unlock_storage() {
     setup_state_file();
     setup_stronghold();


### PR DESCRIPTION
# Description of change
I have changed the locale being reset to default after onboarding in the ```create_new``` reducer

## Links to any relevant issues
- #178 

## How the change has been tested
I've added a test in the /tests/get_state.rs file

## Definition of Done checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
