### PR TITLE
chore: Add Dependabot config for frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "npm"
+    directory: "/unime"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: "disabled"

--- a/README.md
+++ b/README.md
@@ -103,3 +103,16 @@ rd /s /q "%USERPROFILE%\.cargo\git\checkouts"
 ```
 
 _This project was initialized using `create-tauri-app v3.1.1`._
+
+## Dependabot
+
+Dependabot monitors the following dependencies and creates pull requests with dependecy updates:
+
+| Directory | Updates                                                               |
+| :-------- | :-------------------------------------------------------------------- |
+| `/`       | NPM (project root `package.json`) and dependencies of GitHub Actions. |
+| `/unime`  | NPM.                                                                  |
+
+- Update frequency is once per month.
+- Automatic rebasing is disabled to avoid excessive use of GitHub Action minutes.
+- To trigger a rebase, follow the instructions in the pull request.


### PR DESCRIPTION
# Description of change

Add Dependabot config for automated creation of PRs with dependency updates for NPM and GitHub Actions. Updates of Rust dependencies are out of scope to avoid dealing with too many PRs initially. A config for Rust dependencies can be added later on.

Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates

## Links to any relevant issues

Fixes #206.

## How the change has been tested

Dependabot is a GitHub feature. The configuration cannot be tested locally.

The config needs to be fine-tuned over time. E.g. frequency of updates, maximum number of open PRs etc.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
