### PR TITLE
Fix duplicate favorites bug

### DIFF
--- a/unime/src/lib/credentials/CredentialList.svelte
+++ b/unime/src/lib/credentials/CredentialList.svelte
@@ -14,6 +14,7 @@
 
   let credentials: DisplayCredential[];
 
+  // Credentials have to be reactive since state can update while component is mounted.
   $: {
     // First filter out favorites, then filter by type (if applicable).
     credentials = $state.credentials.filter((c) => !c.metadata.is_favorite);

--- a/unime/src/lib/credentials/CredentialList.svelte
+++ b/unime/src/lib/credentials/CredentialList.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-
   import { goto } from '$app/navigation';
   import LL from '$i18n/i18n-svelte';
+
+  import type { DisplayCredential } from '@bindings/display-credential/DisplayCredential';
 
   import IconMessage from '$lib/components/molecules/IconMessage.svelte';
   import ListItemCard from '$lib/components/molecules/ListItemCard.svelte';
@@ -12,16 +12,17 @@
 
   export let credentialType: 'all' | 'data' | 'badges' = 'all';
 
-  $: credentials = $state.credentials;
+  let credentials: DisplayCredential[];
 
-  onMount(async () => {
+  $: {
+    // First filter out favorites, then filter by type (if applicable).
     credentials = $state.credentials.filter((c) => !c.metadata.is_favorite);
     if (credentialType === 'badges') {
       credentials = credentials.filter((c) => (c.data.type as string[]).includes('OpenBadgeCredential'));
     } else if (credentialType === 'data') {
       credentials = credentials.filter((c) => !(c.data.type as string[]).includes('OpenBadgeCredential'));
     }
-  });
+  }
 </script>
 
 {#if credentials?.length > 0}

--- a/unime/src/lib/credentials/Favorites.svelte
+++ b/unime/src/lib/credentials/Favorites.svelte
@@ -13,9 +13,12 @@
 
   export let credentialType: 'all' | 'data' | 'badges' = 'all';
 
-  let favorite_credentials: DisplayCredential[] = $state.credentials.filter((c) => c.metadata.is_favorite);
+  // Make favorite_credentials reactive in case we sort favorites in the future, too.
+  let favorite_credentials: DisplayCredential[];
 
-  onMount(async () => {
+  $: {
+    // Filter out non-favorites, then filter by type (if applicable).
+    favorite_credentials = $state.credentials.filter((c) => c.metadata.is_favorite);
     if (credentialType === 'badges') {
       favorite_credentials = favorite_credentials.filter((c) =>
         (c.data.type as string[]).includes('OpenBadgeCredential'),
@@ -25,7 +28,7 @@
         (c) => !(c.data.type as string[]).includes('OpenBadgeCredential'),
       );
     }
-  });
+  }
 </script>
 
 {#if favorite_credentials.length > 0}


### PR DESCRIPTION
# Description of change

When changing the sort order, favorites are not filtered from the `CredentialList`:

<img src="https://github.com/impierce/identity-wallet/assets/1482402/3ae872c3-f339-46c5-81cf-a2ca3372b0dd" width=50% height=50%>

## Links to any relevant issues

This is a fix on a feature branch.

## How the change has been tested

1. Load the Ferris profile in dev mode.
2. Navigate to "Me".
3. Favorite 2 credentials (don't use the dev mode back button to go back, use the navigation with arrow symbol).
4. Change the sort order.
5. Verify that in all 3 tabs you see favorites and non favorites separated.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
