### PR TITLE
Fix wrong credential images in CredentialList and Favorites

### DIFF
--- a/unime/src/lib/credentials/CredentialList.svelte
+++ b/unime/src/lib/credentials/CredentialList.svelte
@@ -28,20 +28,18 @@
 
 {#if credentials?.length > 0}
   <div class="flex flex-col space-y-2">
-    {#key credentials}
-      {#each credentials as credential}
-        <ListItemCard
-          id={credential.id}
-          title={credential.display_name}
-          description={credential.issuer_name ?? credential.data.issuer?.name ?? credential.data.issuer}
-          type={credential.data.type.includes('OpenBadgeCredential') ? 'badge' : 'data'}
-          on:click={() =>
-            credential.data.type.includes('OpenBadgeCredential')
-              ? goto(`/badges/${credential.id}`)
-              : goto(`/credentials/${credential.id}`)}
-        ></ListItemCard>
-      {/each}
-    {/key}
+    {#each credentials as credential (credential.id)}
+      <ListItemCard
+        id={credential.id}
+        title={credential.display_name}
+        description={credential.issuer_name ?? credential.data.issuer?.name ?? credential.data.issuer}
+        type={credential.data.type.includes('OpenBadgeCredential') ? 'badge' : 'data'}
+        on:click={() =>
+          credential.data.type.includes('OpenBadgeCredential')
+            ? goto(`/badges/${credential.id}`)
+            : goto(`/credentials/${credential.id}`)}
+      ></ListItemCard>
+    {/each}
   </div>
 {:else if $state?.credentials?.length === 0}
   <!-- Only show "No credentials" when there's also no favorites -->

--- a/unime/src/lib/credentials/CredentialList.svelte
+++ b/unime/src/lib/credentials/CredentialList.svelte
@@ -28,6 +28,7 @@
 
 {#if credentials?.length > 0}
   <div class="flex flex-col space-y-2">
+    <!-- Add credential.id as key to help Svelte update the list correctly. -->
     {#each credentials as credential (credential.id)}
       <ListItemCard
         id={credential.id}

--- a/unime/src/lib/credentials/Favorites.svelte
+++ b/unime/src/lib/credentials/Favorites.svelte
@@ -35,7 +35,7 @@
     <p class="text-[13px]/[24px] font-medium text-slate-500 dark:text-white">{$LL.ME.FAVORITES()}</p>
   </div>
   <div class="flex flex-col space-y-2">
-    {#each favorite_credentials as credential}
+    {#each favorite_credentials as credential (credential.id)}
       <ListItemCard
         id={credential.id}
         title={credential.display_name}


### PR DESCRIPTION
# Description of change

When changing the credentials sort order, occasionally the wrong credential image is displayed. Steps to reproduce:

1. Load the Ferris profile.
2. Personal Information is favorite by default. Don't change it.
3. Go to the "Badges" tab. Favorite both badges, one by one. Don't use the dev back button.
4. Go to the "All" tab.
5. Change the sort order to "Date issued".
6. Go to the Badges tab.
7. Teamwork shows the Ferris icon.

<img src="https://github.com/impierce/identity-wallet/assets/1482402/a760d43b-1a58-48c9-8d67-897efaaff64b" width=50% height=50%>

## Links to any relevant issues

This is a fix on a feature branch.

## How the change has been tested

* Use the sequence from the reproduction above. The images should be correct.
* Test other sequences in which you favorite multiple credentials and then change the sort order.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
