### PR TITLE
fix: Pin Rust to v1.77.2 in GitHub Action

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -43,7 +43,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@1.77.1
+        # TODO Set back to @stable (workaround for #224).
+        # uses: dtolnay/rust-toolchain@1.77.2 fails because it does not include rustfmt.
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.77.2
+          components: clippy, rustfmt
 
       - name: Install dependencies
         working-directory: ./unime/src-tauri
@@ -82,7 +87,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@1.77.1
+        # TODO See comment above.
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.77.2
+          components: clippy, rustfmt
+
 
       - name: Install dependencies
         working-directory: ./identity-wallet

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.77.1
 
       - name: Install dependencies
         working-directory: ./unime/src-tauri
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.77.1
 
       - name: Install dependencies
         working-directory: ./identity-wallet


### PR DESCRIPTION
# Description of change

This is not a fix, only a workaround.

## Links to any relevant issues

Related to #224.

## How the change has been tested

Verify that GitHub Action does not break.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
