### PR TITLE
fix: reduce flicker when loading credential images

### DIFF
--- a/unime/src/lib/components/atoms/Image.svelte
+++ b/unime/src/lib/components/atoms/Image.svelte
@@ -21,16 +21,11 @@
   export let id: string;
   export let iconFallback: Icon = 'User';
   export let isTempAsset = false;
-  let assetUrl: string | null = null;
 
-  async function loadImage() {
-    getImageAsset(id, isTempAsset).then((url) => {
-      assetUrl = url;
-    });
-  }
+  let assetUrl: Promise<string | null>;
 
   onMount(() => {
-    loadImage();
+    assetUrl = getImageAsset(id, isTempAsset);
   });
 </script>
 
@@ -53,21 +48,24 @@ Displays an image (loaded from disk) or a fallback component.
 <Image id={'3cf73ecb'} iconFallback={'Bank'} imgClass="h-[64px] w-[64px]" />
 ```
 -->
-{#if assetUrl}
-  <img
-    src={assetUrl}
-    alt="img_{id}"
-    class={twMerge('max-h-full w-full overflow-hidden bg-white object-contain', $$props.imgClass)}
-    on:error={() => warn(`Could not load image: ${id}`)}
-    on:load={() => debug(`Image successfully loaded: ${assetUrl}`)}
-    data-testid="image"
-  />
-{:else}
-  <slot name="fallback">
-    <svelte:component
-      this={icons[iconFallback]}
-      class={twMerge('h-[18px] w-[18px] text-slate-800 dark:text-grey', $$props.iconClass)}
-      data-testid="icon"
+
+{#await assetUrl then src}
+  {#if src}
+    <img
+      {src}
+      alt="img_{id}"
+      class={twMerge('max-h-full w-full overflow-hidden bg-white object-contain', $$props.imgClass)}
+      on:error={() => warn(`Could not load image: ${id}`)}
+      on:load={() => debug(`Image successfully loaded: ${assetUrl}`)}
+      data-testid="image"
     />
-  </slot>
-{/if}
+  {:else}
+    <slot name="fallback">
+      <svelte:component
+        this={icons[iconFallback]}
+        class={twMerge('h-[18px] w-[18px] text-slate-800 dark:text-grey', $$props.iconClass)}
+        data-testid="icon"
+      />
+    </slot>
+  {/if}
+{/await}


### PR DESCRIPTION
# Description of change

The previous handling of images loaded the fallback images immediately. The revised approach awaits a promise that returns the asset URL. The fallback image is shown only when no asset URL could be resolved.

If the asset URL can be resolved, the image is still rendered with a slight delay.

I tried an alternative approach to compute the asset URL in a SvelteKit page load function. But this did not work. Not clear why, but calling Tauri APIs crashes the load function.

The perceived flickering should be less because the fallback does not get rendered by default. But it is possible that you will perceive the delay when the image loads. This is unfortunately a limitation of client-side loading.

![ScreenFlow](https://github.com/impierce/identity-wallet/assets/1482402/716f94a8-38c8-4f7c-8eaa-e1d7f1209130)


## Links to any relevant issues

Fixes issue #182.

## How the change has been tested

Screen record the app while clicking on badges in the Ferris profile. Then use the scrubber to scrub through the recorded images after clicking a badge. You should not see the fallback image loaded. However you will see no image loaded before that image gets loaded.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
