### PR TITLE
fix: reverse sorting order labels, update bindings imports

### DIFF
--- a/unime/src/lib/app/locales.ts
+++ b/unime/src/lib/app/locales.ts
@@ -2,7 +2,7 @@ import type { SvelteComponent } from 'svelte';
 
 import type { SvelteHTMLElements } from 'svelte/elements';
 
-import type { Locale } from '@bindings/Locale';
+import type { Locale } from '@bindings/profile_settings/Locale';
 
 import DE from '~icons/circle-flags/de';
 import GB from '~icons/circle-flags/gb';

--- a/unime/src/lib/connections/ConnectionSummary.svelte
+++ b/unime/src/lib/connections/ConnectionSummary.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import LL from '$i18n/i18n-svelte';
 
-  import type { Connection } from '@bindings/Connection';
+  import type { Connection } from '@bindings/connections/Connection';
   import { open } from '@tauri-apps/plugin-shell';
 
   import Image from '$lib/components/atoms/Image.svelte';

--- a/unime/src/lib/connections/ConnectionsList.svelte
+++ b/unime/src/lib/connections/ConnectionsList.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import LL from '$i18n/i18n-svelte';
 
-  import type { Connection } from '@bindings/Connection';
+  import type { Connection } from '@bindings/connections/Connection';
   import { info } from '@tauri-apps/plugin-log';
 
   import Image from '$lib/components/atoms/Image.svelte';

--- a/unime/src/lib/connections/sorting/SortingSheetButton.svelte
+++ b/unime/src/lib/connections/sorting/SortingSheetButton.svelte
@@ -20,9 +20,9 @@
     if (method === 'name_az') {
       sortOrder = reversed ? $LL.SORT.ORDER.Z_A() : $LL.SORT.ORDER.A_Z();
     } else if (method === 'issue_date_new_old') {
-      sortOrder = reversed ? $LL.SORT.ORDER.NEWEST() : $LL.SORT.ORDER.OLDEST();
+      sortOrder = reversed ? $LL.SORT.ORDER.OLDEST() : $LL.SORT.ORDER.NEWEST();
     } else if (method === 'added_date_new_old') {
-      sortOrder = reversed ? $LL.SORT.ORDER.NEWEST() : $LL.SORT.ORDER.OLDEST();
+      sortOrder = reversed ? $LL.SORT.ORDER.OLDEST() : $LL.SORT.ORDER.NEWEST();
     }
   }
 </script>

--- a/unime/src/lib/connections/utils.test.ts
+++ b/unime/src/lib/connections/utils.test.ts
@@ -1,4 +1,4 @@
-import type { Connection } from '@bindings/Connection';
+import type { Connection } from '@bindings/connections/Connection';
 
 import { groupConnectionsAlphabetically } from './utils';
 

--- a/unime/src/lib/connections/utils.ts
+++ b/unime/src/lib/connections/utils.ts
@@ -1,4 +1,4 @@
-import type { Connection } from '@bindings/Connection';
+import type { Connection } from '@bindings/connections/Connection';
 
 // TODO: replace with native "Object.groupBy" once available
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy

--- a/unime/src/lib/credentials/CredentialList.svelte
+++ b/unime/src/lib/credentials/CredentialList.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import LL from '$i18n/i18n-svelte';
 
-  import type { DisplayCredential } from '@bindings/display-credential/DisplayCredential';
+  import type { DisplayCredential } from '@bindings/credentials/DisplayCredential';
 
   import IconMessage from '$lib/components/molecules/IconMessage.svelte';
   import ListItemCard from '$lib/components/molecules/ListItemCard.svelte';

--- a/unime/src/lib/credentials/Favorites.svelte
+++ b/unime/src/lib/credentials/Favorites.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import LL from '$i18n/i18n-svelte';
 
-  import type { DisplayCredential } from '@bindings/display-credential/DisplayCredential';
+  import type { DisplayCredential } from '@bindings/credentials/DisplayCredential';
 
   import ListItemCard from '$lib/components/molecules/ListItemCard.svelte';
   import { state } from '$lib/stores';

--- a/unime/src/lib/events/History.svelte
+++ b/unime/src/lib/events/History.svelte
@@ -4,8 +4,8 @@
   import LL from '$i18n/i18n-svelte';
   import type { SvelteHTMLElements } from 'svelte/elements';
 
-  import type { HistoryCredential } from '@bindings/HistoryCredential';
-  import type { HistoryEvent } from '@bindings/HistoryEvent';
+  import type { HistoryCredential } from '@bindings/history/HistoryCredential';
+  import type { HistoryEvent } from '@bindings/history/HistoryEvent';
 
   import HistoryEntry from '$lib/events/HistoryEntry.svelte';
   import { state } from '$lib/stores';

--- a/unime/src/lib/events/HistoryEntry.svelte
+++ b/unime/src/lib/events/HistoryEntry.svelte
@@ -3,7 +3,7 @@
   import { formatRelative, type Locale } from 'date-fns';
   import { de, enGB, enUS, nl } from 'date-fns/locale';
 
-  import type { HistoryCredential } from '@bindings/HistoryCredential';
+  import type { HistoryCredential } from '@bindings/history/HistoryCredential';
 
   import ListItemCard from '$lib/components/molecules/ListItemCard.svelte';
   import { state } from '$lib/stores';

--- a/unime/src/routes/(app)/activity/connection/[id]/+page@.svelte
+++ b/unime/src/routes/(app)/activity/connection/[id]/+page@.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/stores';
   import LL from '$i18n/i18n-svelte';
 
-  import type { Connection } from '@bindings/Connection';
+  import type { Connection } from '@bindings/connections/Connection';
 
   import Tabs from '$lib/components/molecules/navigation/Tabs.svelte';
   import TopNavBar from '$lib/components/molecules/navigation/TopNavBar.svelte';

--- a/unime/src/routes/(app)/me/search/RecentSearches.svelte
+++ b/unime/src/routes/(app)/me/search/RecentSearches.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import LL from '$i18n/i18n-svelte';
 
-  import type { DisplayCredential } from '@bindings/display-credential/DisplayCredential';
+  import type { DisplayCredential } from '@bindings/credentials/DisplayCredential';
 
   import ListItemCard from '$lib/components/molecules/ListItemCard.svelte';
   import { dispatch } from '$lib/dispatcher';

--- a/unime/src/routes/utils.ts
+++ b/unime/src/routes/utils.ts
@@ -1,4 +1,4 @@
-import type { AppTheme } from '@bindings/AppTheme';
+import type { AppTheme } from '@bindings/profile_settings/AppTheme';
 
 export function determineTheme(systemPrefersDark: boolean, userPreference: AppTheme): 'light' | 'dark' {
   if (systemPrefersDark) {


### PR DESCRIPTION
# Description of change
The button labels for the sorting order preferences are reversed and thereby show the wrong value.
Also, some `@bindings` imports were not updated.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
