### PR TITLE
refactor: Remove TS errors in `share-credentials` route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
-        "prettier": "^3.3.0",
+        "prettier": "^3.3.2",
         "prettier-plugin-svelte": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.6.5"
       }
@@ -764,9 +764,9 @@
       "dev": true
     },
     "node_modules/prettier": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
-      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
         "prettier": "^3.3.0",
-        "prettier-plugin-svelte": "^3.2.3",
+        "prettier-plugin-svelte": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.6.5"
       }
     },
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.2.3.tgz",
-      "integrity": "sha512-wJq8RunyFlWco6U0WJV5wNCM7zpBFakS76UBSbmzMGpncpK98NZABaE+s7n8/APDCEVNHXC5Mpq+MLebQtsRlg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.2.5.tgz",
+      "integrity": "sha512-vP/M/Goc8z4iVIvrwXwbrYVjJgA0Hf8PO1G4LBh/ocSt6vUP6sLvyu9F3ABEGr+dbKyxZjEKLkeFsWy/yYl0HQ==",
       "dev": true,
       "peerDependencies": {
         "prettier": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
+        "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
         "prettier": "^3.3.0",
         "prettier-plugin-svelte": "^3.2.3",
         "prettier-plugin-tailwindcss": "^0.6.5"
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@ianvs/prettier-plugin-sort-imports": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.2.1.tgz",
-      "integrity": "sha512-NKN1LVFWUDGDGr3vt+6Ey3qPeN/163uR1pOPAlkWpgvAqgxQ6kSdUf1F0it8aHUtKRUzEGcK38Wxd07O61d7+Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
+      "integrity": "sha512-OOMtUcO4J3LoL63dOKAe7bn+lSRRPeit2DqNHpx+wvBp3Grejo2PMaK4Mp1mwy8pnat64ccSgk/lBZbsAdLErw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
         "prettier": "^3.3.0",
         "prettier-plugin-svelte": "^3.2.3",
-        "prettier-plugin-tailwindcss": "^0.6.1"
+        "prettier-plugin-tailwindcss": "^0.6.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.1.tgz",
-      "integrity": "sha512-AnbeYZu0WGj+QgKciUgdMnRxrqcxltleZPgdwfA5104BHM3siBLONN/HLW1yS2HvzSNkzpQ/JAj+LN0jcJO+0w==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.5.tgz",
+      "integrity": "sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==",
       "dev": true,
       "engines": {
         "node": ">=14.21.3"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
     "prettier": "^3.3.0",
     "prettier-plugin-svelte": "^3.2.3",
-    "prettier-plugin-tailwindcss": "^0.6.1"
+    "prettier-plugin-tailwindcss": "^0.6.5"
   },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "format:check": "prettier . --check"
   },
   "devDependencies": {
-    "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
+    "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
     "prettier": "^3.3.0",
     "prettier-plugin-svelte": "^3.2.3",
     "prettier-plugin-tailwindcss": "^0.6.5"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
     "prettier": "^3.3.0",
-    "prettier-plugin-svelte": "^3.2.3",
+    "prettier-plugin-svelte": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.6.5"
   },
   "type": "module"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
-    "prettier": "^3.3.0",
+    "prettier": "^3.3.2",
     "prettier-plugin-svelte": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.6.5"
   },

--- a/unime/src/routes/prompt/share-credentials/+page.svelte
+++ b/unime/src/routes/prompt/share-credentials/+page.svelte
@@ -4,6 +4,8 @@
   import { goto } from '$app/navigation';
   import LL from '$i18n/i18n-svelte';
 
+  import type { CurrentUserPrompt } from '@bindings/user_prompt/CurrentUserPrompt';
+
   import Button from '$lib/components/atoms/Button.svelte';
   import Checkbox from '$lib/components/atoms/Checkbox.svelte';
   import Image from '$lib/components/atoms/Image.svelte';
@@ -17,13 +19,18 @@
   import PlugsConnected from '~icons/ph/plugs-connected-fill';
   import SealCheck from '~icons/ph/seal-check-fill';
 
-  let selected_credentials = $state.credentials?.filter((c) => $state.current_user_prompt.options.indexOf(c.id) > -1);
+  // TypeScript does not know that the `current_user_prompt` is of type `share-credentials`.
+  // Extract the type from `CurrentUserPrompt`.
+  type IsShareCredentialsPrompt<T> = T extends { type: 'share-credentials' } ? T : never;
+  type ShareCredentialsPrompt = IsShareCredentialsPrompt<CurrentUserPrompt>;
 
-  let client_name = $state.current_user_prompt.client_name;
+  const { client_name, logo_uri, options } = $state.current_user_prompt as ShareCredentialsPrompt;
+
+  let selected_credentials = $state.credentials?.filter((c) => options.indexOf(c.id) > -1);
 
   let loading = false;
 
-  const imageId = $state.current_user_prompt?.logo_uri ? hash($state.current_user_prompt?.logo_uri) : '_';
+  $: imageId = logo_uri ? hash(logo_uri) : '_';
 
   // When an error is received, cancel the flow and redirect to the "me" page
   error.subscribe((err) => {
@@ -44,7 +51,7 @@
 
   <div class="flex grow flex-col items-center justify-center space-y-6 p-4">
     <!-- Header -->
-    {#if $state.current_user_prompt.logo_uri}
+    {#if logo_uri}
       <div class="flex h-[75px] w-[75px] overflow-hidden rounded-3xl bg-white p-2 dark:bg-silver">
         <Image id={imageId} isTempAsset={true} />
       </div>


### PR DESCRIPTION
# Description of change

Fix 8 TS errors when running `svelte-check`.

## Links to any relevant issues

Part of #184.

## How the change has been tested

Test if route still renders. `npm run check` should show 8 errors less.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
