### PR TITLE
refactor: Add protocol versions to "About UniMe" page

### DIFF
--- a/unime/src/i18n/de-DE/index.ts
+++ b/unime/src/i18n/de-DE/index.ts
@@ -159,6 +159,9 @@ const de = {
       ABOUT: {
         TITLE: 'Über UniMe',
         NAVBAR_TITLE: 'Über UniMe',
+        SPECIFICATIONS: 'Spezifikationen',
+        VERSION: 'Version',
+        LICENSE: 'Lizenz',
         BUILT_WITH: 'Gebaut mit Tauri',
       },
       FEEDBACK: {

--- a/unime/src/i18n/en/index.ts
+++ b/unime/src/i18n/en/index.ts
@@ -158,6 +158,9 @@ const en = {
       ABOUT: {
         TITLE: 'About UniMe',
         NAVBAR_TITLE: 'About UniMe',
+        SPECIFICATIONS: 'Specifications',
+        VERSION: 'Version',
+        LICENSE: 'License',
         BUILT_WITH: 'Built with Tauri',
       },
       FEEDBACK: {

--- a/unime/src/i18n/i18n-types.ts
+++ b/unime/src/i18n/i18n-types.ts
@@ -443,6 +443,18 @@ type RootTranslation = {
 				 */
 				NAVBAR_TITLE: string
 				/**
+				 * S​p​e​c​i​f​i​c​a​t​i​o​n​s
+				 */
+				SPECIFICATIONS: string
+				/**
+				 * V​e​r​s​i​o​n
+				 */
+				VERSION: string
+				/**
+				 * L​i​c​e​n​s​e
+				 */
+				LICENSE: string
+				/**
 				 * B​u​i​l​t​ ​w​i​t​h​ ​T​a​u​r​i
 				 */
 				BUILT_WITH: string
@@ -807,7 +819,7 @@ type RootTranslation = {
 		 */
 		FAILURE: string
 		/**
-		 * N​o​ ​p​r​o​o​f​ ​o​f​ ​o​w​n​e​r​s​h​i​p​ ​o​f​ ​t​h​e​ ​d​o​m​a​i​n​ ​w​a​s​ ​p​r​o​v​i​d​e​d​ ​w​h​i​c​h​ ​U​n​i​M​e​ ​c​o​u​l​d​ ​v​e​r​i​f​y​.
+		 * U​n​i​M​e​ ​c​o​u​l​d​ ​n​o​t​ ​f​i​n​d​ ​a​n​y​ ​p​r​o​o​f​ ​o​f​ ​t​h​e​ ​d​o​m​a​i​n​'​s​ ​a​s​s​o​c​i​a​t​e​d​ ​i​d​e​n​t​i​t​y​.
 		 */
 		UNKNOWN: string
 		/**
@@ -1274,6 +1286,18 @@ export type TranslationFunctions = {
 				 */
 				NAVBAR_TITLE: () => LocalizedString
 				/**
+				 * Specifications
+				 */
+				SPECIFICATIONS: () => LocalizedString
+				/**
+				 * Version
+				 */
+				VERSION: () => LocalizedString
+				/**
+				 * License
+				 */
+				LICENSE: () => LocalizedString
+				/**
 				 * Built with Tauri
 				 */
 				BUILT_WITH: () => LocalizedString
@@ -1638,7 +1662,7 @@ export type TranslationFunctions = {
 		 */
 		FAILURE: () => LocalizedString
 		/**
-		 * No proof of ownership of the domain was provided which UniMe could verify.
+		 * UniMe could not find any proof of the domain's associated identity.
 		 */
 		UNKNOWN: () => LocalizedString
 		/**

--- a/unime/src/i18n/nl-NL/index.ts
+++ b/unime/src/i18n/nl-NL/index.ts
@@ -158,6 +158,9 @@ const nl = {
       ABOUT: {
         TITLE: 'Over UniMe',
         NAVBAR_TITLE: 'Over UniMe',
+        SPECIFICATIONS: 'Specificaties',
+        VERSION: 'Versie',
+        LICENSE: 'Licentie',
         BUILT_WITH: 'Ontwikkeld met Tauri',
       },
       FEEDBACK: {

--- a/unime/src/routes/(app)/me/settings/about/+page.server.ts
+++ b/unime/src/routes/(app)/me/settings/about/+page.server.ts
@@ -8,25 +8,25 @@ interface Specification {
 }
 
 export const load = (async () => {
-  // https://github.com/impierce/openid4vc?tab=readme-ov-file
+  // https://github.com/impierce/openid4vc?tab=readme-ov-file#rust-library-for-openid-for-verifiable-credentials
 
   const specifications: Specification[] = [
     {
       id: 'OID4VCI',
       description: 'OpenID for Verifiable Credential Issuance',
-      version: 'Working Group Draft 13 published: 8 February 2024',
+      version: 'Working Group Draft 13 (published: 8 February 2024)',
       url: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html',
     },
     {
       id: 'OID4VP',
       description: 'OpenID for Verifiable Presentations',
-      version: 'Working Group Draft 20 published: 29 November 2023',
+      version: 'Working Group Draft 20 (published: 29 November 2023)',
       url: 'https://openid.net/specs/openid-4-verifiable-presentations-1_0-20.html',
     },
     {
       id: 'SIOPv2',
       description: 'Self-Issued OpenID Provider v2',
-      version: 'Working Group Draft 13 published: 28 November 2023',
+      version: 'Working Group Draft 13 (published: 28 November 2023)',
       url: 'https://openid.net/specs/openid-connect-self-issued-v2-1_0-13.html',
     },
   ];

--- a/unime/src/routes/(app)/me/settings/about/+page.server.ts
+++ b/unime/src/routes/(app)/me/settings/about/+page.server.ts
@@ -1,0 +1,37 @@
+import type { PageServerLoad } from './$types';
+
+interface Specification {
+  id: string;
+  description: string;
+  version: string;
+  url: string;
+}
+
+export const load = (async () => {
+  // https://github.com/impierce/openid4vc?tab=readme-ov-file
+
+  const specifications: Specification[] = [
+    {
+      id: 'OID4VCI',
+      description: 'OpenID for Verifiable Credential Issuance',
+      version: 'Working Group Draft 13 published: 8 February 2024',
+      url: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html',
+    },
+    {
+      id: 'OID4VP',
+      description: 'OpenID for Verifiable Presentations',
+      version: 'Working Group Draft 20 published: 29 November 2023',
+      url: 'https://openid.net/specs/openid-4-verifiable-presentations-1_0-20.html',
+    },
+    {
+      id: 'SIOPv2',
+      description: 'Self-Issued OpenID Provider v2',
+      version: 'Working Group Draft 13 published: 28 November 2023',
+      url: 'https://openid.net/specs/openid-connect-self-issued-v2-1_0-13.html',
+    },
+  ];
+
+  return {
+    specifications,
+  };
+}) satisfies PageServerLoad;

--- a/unime/src/routes/(app)/me/settings/about/+page.svelte
+++ b/unime/src/routes/(app)/me/settings/about/+page.svelte
@@ -24,6 +24,7 @@
           {#each data.specifications as spec (spec.id)}
             <div class="flex flex-col items-center">
               <dt class="font-semibold">{`${spec.description} (${spec.id}):`}</dt>
+              <!-- `target="_blank"` opens the spec link in the default browser. -->
               <dd><a href={spec.url} target="_blank" class="underline">{spec.version}</a></dd>
             </div>
           {/each}

--- a/unime/src/routes/(app)/me/settings/about/+page.svelte
+++ b/unime/src/routes/(app)/me/settings/about/+page.svelte
@@ -13,7 +13,7 @@
 <TopNavBar on:back={() => history.back()} title={$LL.SETTINGS.SUPPORT.ABOUT.NAVBAR_TITLE()} />
 
 <div class="content-height flex flex-col bg-silver dark:bg-navy">
-  <h1 class="hidden">{$LL.SETTINGS.SUPPORT.ABOUT.TITLE}</h1>
+  <h1 class="sr-only">{$LL.SETTINGS.SUPPORT.ABOUT.TITLE()}</h1>
   <div
     class="flex flex-col items-center gap-6 pt-4 text-[13px]/[24px] font-normal text-slate-500 opacity-50 dark:text-slate-300"
   >

--- a/unime/src/routes/(app)/me/settings/about/+page.svelte
+++ b/unime/src/routes/(app)/me/settings/about/+page.svelte
@@ -3,24 +3,43 @@
 
   import { TopNavBar } from '$lib/components';
   import { HeartFillIcon } from '$lib/icons';
+
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
 <TopNavBar on:back={() => history.back()} title={$LL.SETTINGS.SUPPORT.ABOUT.NAVBAR_TITLE()} />
+
 <div class="content-height flex flex-col bg-silver dark:bg-navy">
-  <div class="flex flex-col p-8">
-    <!-- Footer -->
-    <div
-      class="flex flex-col items-center pt-4 text-[13px]/[24px] font-normal text-slate-500 opacity-50 dark:text-slate-300"
-    >
-      <!-- <div class="pb-4" /> -->
+  <h1 class="hidden">{$LL.SETTINGS.SUPPORT.ABOUT.TITLE}</h1>
+  <div
+    class="flex flex-col items-center gap-6 pt-4 text-[13px]/[24px] font-normal text-slate-500 opacity-50 dark:text-slate-300"
+  >
+    <section class="flex flex-col items-center">
+      <h2 class="mb-3 font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.SPECIFICATIONS()}</h2>
+      <dl class="flex flex-col items-center gap-3">
+        {#each data.specifications as spec (spec.id)}
+          <div class="flex flex-col items-center">
+            <dt class="font-semibold">{`${spec.description} (${spec.id}):`}</dt>
+            <dd><a href={spec.url} class="underline">{spec.version}</a></dd>
+          </div>
+        {/each}
+      </dl>
+    </section>
+    <section class="flex flex-col items-center">
+      <h2 class="mb-3 font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.VERSION()}</h2>
       <div>0.6.2</div>
       <div class="flex items-center pb-4">
         <p>{$LL.SETTINGS.SUPPORT.ABOUT.BUILT_WITH()}</p>
         <HeartFillIcon class="pl-1" />
       </div>
+    </section>
+    <section class="flex flex-col items-center">
+      <h2 class="mb-3 font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.LICENSE()}</h2>
       <div>Apache License 2.0</div>
-      <div>2024 Impierce Technologies</div>
-    </div>
+      <div>{`${new Date().getFullYear()} Impierce Technologies`}</div>
+    </section>
   </div>
 </div>
 

--- a/unime/src/routes/(app)/me/settings/about/+page.svelte
+++ b/unime/src/routes/(app)/me/settings/about/+page.svelte
@@ -3,6 +3,7 @@
 
   import { TopNavBar } from '$lib/components';
   import { HeartFillIcon } from '$lib/icons';
+  import { state } from '$lib/stores';
 
   import type { PageData } from './$types';
 
@@ -16,17 +17,19 @@
   <div
     class="flex flex-col items-center gap-6 pt-4 text-[13px]/[24px] font-normal text-slate-500 opacity-50 dark:text-slate-300"
   >
-    <section class="flex flex-col items-center">
-      <h2 class="mb-3 font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.SPECIFICATIONS()}</h2>
-      <dl class="flex flex-col items-center gap-3">
-        {#each data.specifications as spec (spec.id)}
-          <div class="flex flex-col items-center">
-            <dt class="font-semibold">{`${spec.description} (${spec.id}):`}</dt>
-            <dd><a href={spec.url} class="underline">{spec.version}</a></dd>
-          </div>
-        {/each}
-      </dl>
-    </section>
+    {#if $state.dev_mode !== 'Off'}
+      <section class="flex flex-col items-center">
+        <h2 class="mb-3 font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.SPECIFICATIONS()}</h2>
+        <dl class="flex flex-col items-center gap-3">
+          {#each data.specifications as spec (spec.id)}
+            <div class="flex flex-col items-center">
+              <dt class="font-semibold">{`${spec.description} (${spec.id}):`}</dt>
+              <dd><a href={spec.url} class="underline">{spec.version}</a></dd>
+            </div>
+          {/each}
+        </dl>
+      </section>
+    {/if}
     <section class="flex flex-col items-center">
       <h2 class="mb-3 font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.VERSION()}</h2>
       <div>0.6.2</div>

--- a/unime/src/routes/(app)/me/settings/about/+page.svelte
+++ b/unime/src/routes/(app)/me/settings/about/+page.svelte
@@ -24,7 +24,7 @@
           {#each data.specifications as spec (spec.id)}
             <div class="flex flex-col items-center">
               <dt class="font-semibold">{`${spec.description} (${spec.id}):`}</dt>
-              <dd><a href={spec.url} class="underline">{spec.version}</a></dd>
+              <dd><a href={spec.url} target="_blank" class="underline">{spec.version}</a></dd>
             </div>
           {/each}
         </dl>


### PR DESCRIPTION
# Description of change

List the specs and their versions used in UniMe's about page but only in dev mode.

## Links to any relevant issues

Fixes #265.

## How the change has been tested

Visual check of the "About UniMe" page (turn dev mode on and off).

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
