### PR TITLE
refactor: Fix more TypeScript errors

### DIFF
--- a/unime/src/lib/stores.ts
+++ b/unime/src/lib/stores.ts
@@ -37,6 +37,16 @@ const empty_state: AppState = {
     locale: 'en-US',
     profile: null,
     preferred_did_method: 'did:jwk',
+    sorting_preferences: {
+      connections: {
+        sort_method: 'name_az',
+        reverse: false,
+      },
+      credentials: {
+        sort_method: 'name_az',
+        reverse: false,
+      },
+    },
   },
   current_user_prompt: null,
   user_journey: null,

--- a/unime/src/routes/(app)/+layout.svelte
+++ b/unime/src/routes/(app)/+layout.svelte
@@ -4,7 +4,7 @@
 
   import { BottomNavBar } from '$lib/components';
 
-  $: active = $page.route.id?.split('/').at(2) ?? 'me';
+  $: active = ($page.route.id?.split('/').at(2) ?? 'me') as 'me' | 'scan' | 'activity';
 </script>
 
 <!--

--- a/unime/src/routes/+error.svelte
+++ b/unime/src/routes/+error.svelte
@@ -7,9 +7,9 @@
 
 <div class="flex h-screen flex-col items-center justify-center p-4">
   <div class="rounded bg-red-100 p-4">
-    <h2 class="font-mono text-sm text-red-600">{$page.error.message}</h2>
+    <h2 class="font-mono text-sm text-red-600">{$page.error?.message}</h2>
     <div class="pt-4 font-mono text-sm font-semibold text-red-800 opacity-50">
-      {$page.error.errorId}
+      {$page.error?.errorId}
     </div>
   </div>
   <Button variant="secondary" on:click={() => goto('/me')} label="Go back"></Button>

--- a/unime/src/routes/prompt/accept-connection/+page.svelte
+++ b/unime/src/routes/prompt/accept-connection/+page.svelte
@@ -5,7 +5,7 @@
   import LL from '$i18n/i18n-svelte';
   import { fade } from 'svelte/transition';
 
-  import type { ValidationResult } from '@bindings/user_prompt/ValidationResult';
+  import type { CurrentUserPrompt } from '@bindings/user_prompt/CurrentUserPrompt';
   import { createPopover, melt } from '@melt-ui/svelte';
 
   import { Button, Image, PaddedIcon, TopNavBar } from '$lib/components';
@@ -27,15 +27,16 @@
 
   let loading = false;
 
-  let client_name = $state.current_user_prompt.client_name;
+  // TypeScript does not know that the `current_user_prompt` is of type `accept-connection`.
+  // Extract the type from `CurrentUserPrompt`.
+  type IsAcceptConnectionPrompt<T> = T extends { type: 'accept-connection' } ? T : never;
+  type AcceptConnectionPrompt = IsAcceptConnectionPrompt<CurrentUserPrompt>;
 
-  const previously_connected = $state.current_user_prompt.previously_connected;
+  const { client_name, domain_validation, logo_uri, previously_connected, redirect_uri } =
+    $state.current_user_prompt as AcceptConnectionPrompt;
 
-  const domain_validation: ValidationResult = $state.current_user_prompt.domain_validation;
-
-  const hostname = new URL($state.current_user_prompt.redirect_uri).hostname;
-
-  const imageId = $state.current_user_prompt?.logo_uri ? hash($state.current_user_prompt?.logo_uri) : '_';
+  $: ({ hostname } = new URL(redirect_uri));
+  $: imageId = logo_uri ? hash(logo_uri) : '_';
 
   // When an error is received, cancel the flow and redirect to the "me" page
   error.subscribe((err) => {
@@ -55,7 +56,7 @@
   <TopNavBar title={$LL.SCAN.CONNECTION_REQUEST.NAVBAR_TITLE()} on:back={() => history.back()} disabled={loading} />
 
   <div class="flex grow flex-col items-center justify-center space-y-6 p-4">
-    {#if $state.current_user_prompt.logo_uri}
+    {#if logo_uri}
       <div
         class="flex h-[75px] w-[75px] items-center justify-center overflow-hidden rounded-3xl bg-white p-2 dark:bg-silver"
       >


### PR DESCRIPTION
# Description of change

The goal of #184 is to eliminate all TypeScript errors so we can turn on `svelte-check` in CI. This PR applies changes that are stuck in #256. It brings the number of TS errors down from 49 to 33.

## Links to any relevant issues

- This PR is part of #184.

## How the change has been tested

Manually test affected routes.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
