### PR TITLE
fix: remove unwanted text on badges route when badge is favorite

### DIFF
--- a/unime/src/routes/badges/[id]/+page.svelte
+++ b/unime/src/routes/badges/[id]/+page.svelte
@@ -94,7 +94,7 @@
               },
             })}
         >
-          {#if isFavorite}HeartStraightRegularIcon <HeartStraightFillIcon class="h-6 w-6 dark:text-white" />
+          {#if isFavorite}<HeartStraightFillIcon class="h-6 w-6 dark:text-white" />
           {:else}
             <HeartStraightRegularIcon class="h-6 w-6 dark:text-white" />
           {/if}


### PR DESCRIPTION
# Description of change

Remove text that was accidentally introduced during refactoring in previous PR.

## Links to any relevant issues

- Fixes #296.

## How the change has been tested

Tap on a badge in the credentials overview and then favorite it. It should not show the text from the screenshot in issue #296.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
