### PR TITLE
chore: Add `name` prop to root `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "identity-wallet",
       "workspaces": [
         "unime"
       ],

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "identity-wallet",
   "workspaces": [
     "unime"
   ],


### PR DESCRIPTION
# Description of change

Add a `name` prop to the root `package.json` to prevent unwanted changes in `package-lock.json` when running `npm i` with `git worktree`.

## Links to any relevant issues

- Fixes #316.

## How the change has been tested

Rename project directory of cloned repo to something other than `identity-wallet`. Running `npm i` should not alter `package-lock.json`.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
