### PR TITLE
fix: fetch credential logo URI from `logo.uri`

### DIFF
--- a/identity-wallet/src/state/qr_code/reducers/read_credential_offer.rs
+++ b/identity-wallet/src/state/qr_code/reducers/read_credential_offer.rs
@@ -107,35 +107,7 @@ pub async fn read_credential_offer(state: AppState, action: Action) -> Result<Ap
         info!("issuer_name in credential_offer: {:?}", issuer_name);
         info!("logo_uri in credential_offer: {:?}", logo_uri);
 
-        for (credential_configuration_id, credential_configuration) in credential_configurations.iter() {
-            let credential_logo_url = credential_configuration
-                .display
-                .first()
-                .and_then(|value| value.get("logo").and_then(|value| value.get("url")));
-
-            info!("credential_logo_url: {:?}", credential_logo_url);
-
-            if let Some(credential_logo_url) = credential_logo_url {
-                debug!(
-                    "{}",
-                    format!("Downloading credential logo from url: {}", credential_logo_url)
-                );
-                if let Some(credential_logo_url) = credential_logo_url
-                    .as_str()
-                    .and_then(|s| s.parse::<reqwest::Url>().ok())
-                {
-                    let _ = download_asset(
-                        credential_logo_url,
-                        format!("credential_{}", credential_configuration_id).as_str(),
-                    )
-                    .await;
-                }
-            }
-
-            if credential_logo_url.is_none() && logo_uri.is_none() {
-                debug!("No logo found in metadata.");
-            }
-        }
+        download_credential_logos(&credential_configurations).await;
 
         if logo_uri.is_some() {
             debug!(
@@ -166,4 +138,34 @@ pub async fn read_credential_offer(state: AppState, action: Action) -> Result<Ap
     }
 
     Ok(state)
+}
+
+/// Downloads all the Credential logos.
+async fn download_credential_logos(
+    credential_configurations: &HashMap<String, CredentialConfigurationsSupportedObject>,
+) {
+    for (credential_configuration_id, credential_configuration) in credential_configurations.iter() {
+        let credential_logo_uri = credential_configuration
+            .display
+            .first()
+            .and_then(|value| value["logo"]["uri"].as_str());
+
+        info!("credential_logo_uri: {:?}", credential_logo_uri);
+
+        if let Some(credential_logo_uri) = credential_logo_uri {
+            debug!(
+                "{}",
+                format!("Downloading credential logo from URI: {}", credential_logo_uri)
+            );
+            if let Ok(credential_logo_uri) = credential_logo_uri.parse::<reqwest::Url>() {
+                let _ = download_asset(
+                    credential_logo_uri,
+                    format!("credential_{}", credential_configuration_id).as_str(),
+                )
+                .await;
+            } else {
+                debug!("Failed to parse credential logo URI: {}", credential_logo_uri);
+            }
+        }
+    }
 }

--- a/unime/src-tauri/tests/tests/credential_offer.rs
+++ b/unime/src-tauri/tests/tests/credential_offer.rs
@@ -68,7 +68,7 @@ async fn download_credential_logo() {
                             "name": "University Credential",
                             "locale": "en-US",
                             "logo": {
-                                "url": format!("{}/logo/credential.svg", &mock_server.uri()),
+                                "uri": format!("{}/logo/credential.svg", &mock_server.uri()),
                                 "alternative_text": "a square logo of a university"
                             },
                             "background_color": "#12107c",


### PR DESCRIPTION
# Description of change
#301 already fixed that the Credential Issuers logo is fetched from `logo.uri` (instead of `logo.url`).

This PR does the same for the individual Credential logo's.

Before:
![image](https://github.com/user-attachments/assets/de4f2fd1-d61a-4ca7-ba7b-42dde5e750f4)

After:
![image](https://github.com/user-attachments/assets/4d18ba9e-0f6b-4395-8e48-5ec1e523e39b)

## Links to any relevant issues
- #300

## How the change has been tested
Tested manually against https://staging.client.ngdil.com/demo

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
