### PR TITLE
refactor: Wire up Tauri listeners in `onMount` of root layout

### DIFF
--- a/unime/src/lib/stores.ts
+++ b/unime/src/lib/stores.ts
@@ -2,14 +2,6 @@ import { writable } from 'svelte/store';
 
 // TODO: run some copy task instead of importing across root to make the frontend independent
 import type { AppState } from '@bindings/AppState';
-import { listen } from '@tauri-apps/api/event';
-import { error as err } from '@tauri-apps/plugin-log';
-
-interface ErrorEvent {
-  event: string;
-  payload: string;
-  id: number;
-}
 
 interface OnboardingState {
   name?: string;
@@ -48,22 +40,18 @@ const empty_state: AppState = {
 };
 
 /**
- * A store that listens for updates to the application state emitted by the Rust backend.
- * If the frontend intends to change the state, it must dispatch an action to the backend.
+ * This store contains the frontend state.
+ * It may be altered only by the `state-changed` Tauri listener.
+ * The frontend must dispatch an action to the backend to change state.
  */
 // TODO: make read-only
 export const state = writable<AppState>(empty_state);
 
 /**
- * A store that listens for errors emitted by the Rust backend.
+ * This store contains errors to be displayed by an error toast.
+ * It may be altered only by the `error` Tauri listener.
  */
-export const error = writable<string | undefined>(undefined, (set) => {
-  listen('error', (event: ErrorEvent) => {
-    err(`Error: ${event.payload}`);
-    set(event.payload);
-  });
-  // TODO: unsubscribe from listener!
-});
+export const error = writable<string | undefined>(undefined);
 
 /**
  * This store is only used by the frontend for storing state during onboarding.

--- a/unime/src/lib/stores.ts
+++ b/unime/src/lib/stores.ts
@@ -41,7 +41,7 @@ const empty_state: AppState = {
 
 /**
  * This store contains the frontend state.
- * It may be altered only by the `state-changed` Tauri listener.
+ * It may be altered only by the `state-changed` Tauri event listener.
  * The frontend must dispatch an action to the backend to change state.
  */
 // TODO: make read-only
@@ -49,7 +49,7 @@ export const state = writable<AppState>(empty_state);
 
 /**
  * This store contains errors to be displayed by an error toast.
- * It may be altered only by the `error` Tauri listener.
+ * It may be altered only by the `error` Tauri event listener.
  */
 export const error = writable<string | undefined>(undefined);
 

--- a/unime/src/lib/stores.ts
+++ b/unime/src/lib/stores.ts
@@ -1,18 +1,9 @@
-import { goto } from '$app/navigation';
-import { setLocale } from '$i18n/i18n-svelte';
-import type { Locales } from '$i18n/i18n-types';
 import { writable } from 'svelte/store';
 
 // TODO: run some copy task instead of importing across root to make the frontend independent
 import type { AppState } from '@bindings/AppState';
 import { listen } from '@tauri-apps/api/event';
-import { error as err, info } from '@tauri-apps/plugin-log';
-
-interface StateChangedEvent {
-  event: string;
-  payload: AppState;
-  id: number;
-}
+import { error as err } from '@tauri-apps/plugin-log';
 
 interface ErrorEvent {
   event: string;
@@ -61,21 +52,7 @@ const empty_state: AppState = {
  * If the frontend intends to change the state, it must dispatch an action to the backend.
  */
 // TODO: make read-only
-export const state = writable<AppState>(empty_state, (set) => {
-  listen('state-changed', (event: StateChangedEvent) => {
-    const state = event.payload;
-
-    set(state);
-    setLocale(state.profile_settings.locale as Locales);
-
-    if (state.current_user_prompt?.type === 'redirect') {
-      const redirect_target = state.current_user_prompt.target;
-      info(`Redirecting to: "/${redirect_target}"`);
-      goto(`/${redirect_target}`);
-    }
-  });
-  // TODO: unsubscribe from listener!
-});
+export const state = writable<AppState>(empty_state);
 
 /**
  * A store that listens for errors emitted by the Rust backend.

--- a/unime/src/routes/+layout.svelte
+++ b/unime/src/routes/+layout.svelte
@@ -30,12 +30,18 @@
   import '../app.css';
 
   let detachConsole: UnlistenFn;
+  let unlistenError: UnlistenFn;
   let unlistenStateChanged: UnlistenFn;
 
   onMount(async () => {
     detachConsole = await attachConsole();
 
     loadAllLocales(); //TODO: performance: only load locale on user request
+
+    unlistenError = await listen('error', (event) => {
+      error(`Error: ${event.payload}`);
+      errorState.set(event.payload as string);
+    });
 
     unlistenStateChanged = await listen('state-changed', (event) => {
       // Set frontend state to state received from backend.
@@ -73,6 +79,7 @@
   onDestroy(() => {
     // Destroy in reverse order.
     unlistenStateChanged();
+    unlistenError();
     detachConsole();
   });
 


### PR DESCRIPTION
# Description of change

Since #246 popped up twice recently, this PR refactors how the backend state is passed into the frontend state.

Instead of wiring Tauri listeners up when corresponding states get their first subscriber, now the listeners are wired up in the `onMount` of the root layout. This is the only component that is guaranteed to exist at any time while UniMe is open.

It's not clear if this will fix #246. If nothing else, this refactoring makes it cleaner and easier to understand where the Tauri listeners are wired up.

## Links to any relevant issues

- Related to #246. 

## How the change has been tested

- Testing if #246 has been fixed would only be possible by merging into `dev` and observing over a longer period if #246 occurs again.
- Reviewers need to do spot checks on different routes in the app to test if it works as expected. Also an error should be triggered to test the error toast.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
