### PR TITLE
chore: bump `did_manager`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation",
  "core-graphics",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
  "objc",
 ]
@@ -1316,7 +1316,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -1365,7 +1365,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1867,8 +1867,8 @@ dependencies = [
  "multibase 0.8.0",
  "serde_jcs",
  "serde_json",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static-iref",
 ]
 
@@ -1908,29 +1908,28 @@ dependencies = [
  "p256 0.13.2",
  "serde_json",
  "simple_asn1 0.5.4",
- "ssi-crypto",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-crypto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
 [[package]]
 name = "did-web"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e239187ee5cf6b778c75252ad22bb8289508dcaf05a7c718222a3093460ca0d2"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
 dependencies = [
  "async-trait",
  "http 0.2.12",
  "reqwest 0.11.27",
  "serde_json",
- "ssi-dids",
+ "ssi-dids 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
 ]
 
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "bls12_381_plus 0.8.15",
  "identity_iota",
@@ -1944,44 +1943,42 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "did-jwk",
  "identity_iota",
- "identity_storage",
  "identity_stronghold",
  "iota-sdk",
  "log",
  "serde_json",
  "shared",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "did-method-key",
  "identity_iota",
- "identity_storage",
  "identity_stronghold",
  "iota-sdk",
  "jsonwebkey",
  "log",
  "serde_json",
  "shared",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 
 [[package]]
 name = "did_manager"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "consumer",
  "producer",
@@ -2009,18 +2006,17 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "did-web",
  "identity_iota",
- "identity_storage",
  "identity_stronghold",
  "iota-sdk",
  "log",
  "serde_json",
  "shared",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "url",
  "urlencoding",
@@ -2630,21 +2626,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2657,12 +2644,6 @@ dependencies = [
  "quote",
  "syn 2.0.71",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -3605,19 +3586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.30",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -5594,23 +5562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6128,58 +6079,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.71",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "300.3.1+3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -6897,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "producer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -7249,13 +7152,11 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.30",
  "hyper-rustls 0.24.2",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7267,7 +7168,6 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -8197,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?rev=fa48f4c#fa48f4c8add6ca4375546a4ca0a51c68749cb6e6"
+source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
 dependencies = [
  "identity_iota",
  "identity_storage",
@@ -8373,7 +8273,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases 0.2.1",
  "core-graphics",
- "foreign-types 0.5.0",
+ "foreign-types",
  "js-sys",
  "log",
  "objc2",
@@ -8459,7 +8359,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2c479690955bebece0279a5b1ab9d7d584402caed9f56ecec346d0bc63661f"
 dependencies = [
  "bs58",
- "ssi-jwk",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "ssi-caips"
+version = "0.1.0"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
+dependencies = [
+ "bs58",
+ "ssi-jwk 0.1.2 (git+https://github.com/impierce/spruceid-ssi.git)",
  "thiserror",
 ]
 
@@ -8468,6 +8378,11 @@ name = "ssi-contexts"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3009b82cbae3d88a76f15460fb5fb3f30a1673eb0359ac6917ffaa3c57f7164"
+
+[[package]]
+name = "ssi-contexts"
+version = "0.1.5"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
 
 [[package]]
 name = "ssi-core"
@@ -8481,10 +8396,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssi-core"
+version = "0.1.0"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
+dependencies = [
+ "async-trait",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "ssi-crypto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c511fdba8466006f4de1086fee5f38fd220eac5eeaf0270dbfde3e9d538030e7"
+dependencies = [
+ "bs58",
+ "digest 0.9.0",
+ "k256",
+ "keccak-hash",
+ "ripemd160",
+ "sha2 0.10.8",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "ssi-crypto"
+version = "0.1.1"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
 dependencies = [
  "bs58",
  "digest 0.9.0",
@@ -8513,10 +8453,34 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "ssi-caips",
- "ssi-core",
- "ssi-json-ld",
- "ssi-jwk",
+ "ssi-caips 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-json-ld 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static-iref",
+ "thiserror",
+]
+
+[[package]]
+name = "ssi-dids"
+version = "0.1.1"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bs58",
+ "chrono",
+ "derive_builder",
+ "hex",
+ "iref",
+ "multibase 0.8.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "ssi-caips 0.1.0 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-core 0.1.0 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-json-ld 0.2.2 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-jwk 0.1.2 (git+https://github.com/impierce/spruceid-ssi.git)",
  "static-iref",
  "thiserror",
 ]
@@ -8537,8 +8501,29 @@ dependencies = [
  "lazy_static",
  "locspan",
  "rdf-types",
- "ssi-contexts",
- "ssi-crypto",
+ "ssi-contexts 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-crypto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static-iref",
+ "thiserror",
+]
+
+[[package]]
+name = "ssi-json-ld"
+version = "0.2.2"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
+dependencies = [
+ "async-std",
+ "combination",
+ "futures",
+ "grdf",
+ "iref",
+ "json-ld",
+ "json-syntax",
+ "lazy_static",
+ "locspan",
+ "rdf-types",
+ "ssi-contexts 0.1.5 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-crypto 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
  "static-iref",
  "thiserror",
 ]
@@ -8563,7 +8548,26 @@ dependencies = [
  "rsa",
  "serde",
  "simple_asn1 0.5.4",
- "ssi-crypto",
+ "ssi-crypto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "unsigned-varint",
+ "zeroize",
+]
+
+[[package]]
+name = "ssi-jwk"
+version = "0.1.2"
+source = "git+https://github.com/impierce/spruceid-ssi.git#ff91409b2a38188cf71268d1bfaaba7ede006d08"
+dependencies = [
+ "base64 0.12.3",
+ "lazy_static",
+ "multibase 0.9.1",
+ "num-bigint",
+ "num-derive 0.3.3",
+ "num-traits",
+ "serde",
+ "simple_asn1 0.5.4",
+ "ssi-crypto 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
  "thiserror",
  "unsigned-varint",
  "zeroize",
@@ -9396,16 +9400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9845,6 +9839,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-shell",
+ "tauri-utils",
  "tempfile",
  "tokio",
  "typetag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "bls12_381_plus 0.8.15",
  "identity_iota",
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "did_manager"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "consumer",
  "producer",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "producer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager.git?branch=fix/remove-openssl#7017e2f1fe5b3e93d8af24a29dea21c0f0a6519b"
+source = "git+https://github.com/impierce/did-manager.git?rev=2b88f55#2b88f55b8f5e42aa794a701c5fe11bc962250139"
 dependencies = [
  "identity_iota",
  "identity_storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ tauri = { version = "=2.0.0-beta.24", features = [
     "rustls-tls",
 ] }
 
-did_manager = { git = "https://github.com/impierce/did-manager.git", rev = "fa48f4c" }
+did_manager = { git = "https://github.com/impierce/did-manager.git", branch = "fix/remove-openssl" }
 jsonwebtoken = "9.3"
 log = "^0.4"
 oid4vc = { git = "https://git@github.com/impierce/openid4vc.git", rev = "d095db0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ tauri = { version = "=2.0.0-beta.24", features = [
     "rustls-tls",
 ] }
 
-did_manager = { git = "https://github.com/impierce/did-manager.git", branch = "fix/remove-openssl" }
+did_manager = { git = "https://github.com/impierce/did-manager.git", rev = "2b88f55" }
 jsonwebtoken = "9.3"
 log = "^0.4"
 oid4vc = { git = "https://git@github.com/impierce/openid4vc.git", rev = "d095db0" }

--- a/unime/src-tauri/Cargo.toml
+++ b/unime/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "=2.0.0-beta.19", features = [] }
+tauri-utils = { version = "=2.0.0-beta.19", features = [ "build" ] }
 
 [dependencies]
 tauri.workspace = true


### PR DESCRIPTION
# Description of change
Bumping `did_manager` so that there's no indirect dependency on `openssl` anymore. The `openssl` dependency previously blocked us to release a new UniMe version for Android (see #326) 

## Links to any relevant issues
- #326

## How the change has been tested
Successfully built UniMe for Android.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
