### PR TITLE
fix: create `assets` directory recursively

### DIFF
--- a/identity-wallet/src/persistence.rs
+++ b/identity-wallet/src/persistence.rs
@@ -42,10 +42,8 @@ pub fn initialize_storage(app_handle: &tauri::AppHandle) -> anyhow::Result<()> {
     }
     info!("STATE_FILE: {}", STATE_FILE.lock().unwrap().display());
     info!("STRONGHOLD: {}", STRONGHOLD.lock().unwrap().display());
-    // TODO: on iOS, when running the app for the first time,
-    // is the assets folder even created?
-    // bug: images are not downloaded/displayed for a credential offer (only on first start of the app)
-    match fs::create_dir(ASSETS_DIR.lock().unwrap().as_path()) {
+
+    match fs::create_dir_all(ASSETS_DIR.lock().unwrap().as_path()) {
         Ok(_) => info!("ASSETS_DIR: created"),
         Err(e) => info!("ASSETS_DIR: {}", e),
     };


### PR DESCRIPTION
# Description of change
Fixes a bug in iOS where the `assets` directory was not created on first start of the app.

## Links to any relevant issues
n/a

## How the change has been tested
Physical iOS install, scanning current NGDIL QR codes.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
