### PR TITLE
fix: Random blank pages for some NGDIL credentials

### DIFF
--- a/unime/src/routes/credentials/[id]/DefaultRenderer.svelte
+++ b/unime/src/routes/credentials/[id]/DefaultRenderer.svelte
@@ -10,13 +10,17 @@
   // `enrichment`: custom metadata field related for NGDIL demo.
   const hideFields: string[] = ['enrichment', 'id', 'type'];
 
-  $: fields = Object.keys(credential.data.credentialSubject).filter((field) => !hideFields.includes(field));
+  function isDataUrl(value: unknown): boolean {
+    return typeof value === 'string' && value.startsWith('data:image/');
+  }
+  // `fields` does not have to be reactive because `credential` never changes while component is mounted.
+  let fields = Object.keys(credential.data.credentialSubject).filter((field) => !hideFields.includes(field));
 </script>
 
 {#if fields}
   <div class="flex flex-col gap-4">
     {#each fields as field}
-      {#if credential.data.credentialSubject[field].startsWith('data:image/')}
+      {#if isDataUrl(credential.data.credentialSubject[field])}
         <DataUrlImageRenderer key={field} dataUrl={credential.data.credentialSubject[field]} />
       {:else}
         <div class="rounded-xl bg-background px-4 py-3 text-[13px]/[24px]">


### PR DESCRIPTION
# Description of change

Since the bug occurs during page rendering, I was unable to set a breakpoint and see what type of data is in a field when `startsWith` is invoked to check for a data URL. None of the `credentialSubjects` rendered with the `DefaultRenderer` contain anything other than `string` or something that can be coerced to a string.

Therefore, it is not clear why the `DefaultRenderer` should not be able to call `startsWidth`. To be on the safe side, it now checks if the type is string before checking if a field is a data URL.

## Links to any relevant issues

- Fixes #372.

## How the change has been tested

Load the NGDIL credentials as described in #371 and test for every credential if it renders.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
