### PR TITLE
fix: enable deserialization of trusted entries from both maps and arrays

### DIFF
--- a/identity-wallet/src/state/trust_list/mod.rs
+++ b/identity-wallet/src/state/trust_list/mod.rs
@@ -64,17 +64,27 @@ pub struct TrustList {
     /// Custom true: TrustList's can be created in dev mode at any time.
     #[serde(default)]
     pub custom: bool,
-    #[serde(deserialize_with = "deserialize_domains")]
+    #[serde(deserialize_with = "deserialize_entries")]
     #[ts(type = "Record<string, boolean>")]
     pub entries: HashMap<url::Url, bool>,
 }
 
-fn deserialize_domains<'de, D>(deserializer: D) -> Result<HashMap<Url, bool>, D::Error>
+fn deserialize_entries<'de, D>(deserializer: D) -> Result<HashMap<Url, bool>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let domains: Vec<Url> = Vec::deserialize(deserializer)?;
-    Ok(domains.into_iter().map(|domain| (domain, true)).collect())
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Entries {
+        Array(Vec<Url>),
+        Map(HashMap<Url, bool>),
+    }
+
+    let entries = Entries::deserialize(deserializer)?;
+    match entries {
+        Entries::Array(array) => Ok(array.into_iter().map(|url| (url, true)).collect()),
+        Entries::Map(map) => Ok(map),
+    }
 }
 
 impl Default for TrustList {

--- a/identity-wallet/src/state/trust_list/mod.rs
+++ b/identity-wallet/src/state/trust_list/mod.rs
@@ -127,3 +127,55 @@ impl TrustList {
         self.entries.iter()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use identity_iota::core::FromJson;
+
+    #[test]
+    fn trust_list_successfully_deserializes_from_entries_map() {
+        assert_eq!(
+            TrustList {
+                id: "b01f4a74-3005-4749-a030-c5444bc4dab5".to_string(),
+                display_name: "Test List".to_string(),
+                custom: false,
+                entries: HashMap::from_json_value(serde_json::json!({
+                    "https://example.org": true,
+                }))
+                .unwrap()
+            },
+            serde_json::from_value(serde_json::json!({
+                "id": "b01f4a74-3005-4749-a030-c5444bc4dab5",
+                "display_name": "Test List",
+                "entries": {
+                    "https://example.org": true,
+                },
+            }))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn trust_list_successfully_deserializes_from_entries_array() {
+        assert_eq!(
+            TrustList {
+                id: "b01f4a74-3005-4749-a030-c5444bc4dab5".to_string(),
+                display_name: "Test List".to_string(),
+                custom: false,
+                entries: HashMap::from_json_value(serde_json::json!({
+                    "https://example.org": true,
+                }))
+                .unwrap()
+            },
+            serde_json::from_value(serde_json::json!({
+                "id": "b01f4a74-3005-4749-a030-c5444bc4dab5",
+                "display_name": "Test List",
+                "entries": [
+                    "https://example.org",
+                ],
+            }))
+            .unwrap()
+        );
+    }
+}


### PR DESCRIPTION
# Description of change
The deserialization of `TrustList` [which was introduced in a previous PR](https://github.com/impierce/identity-wallet/pull/353#discussion_r1863579920) only allowed deserialization from Arrays and was lacking deserialization from maps.

This caused an error when loading the app state from the state file which in turn resulted in UniMe being redirected to the Welcome page. 

## Links to any relevant issues
n/a

## How the change has been tested
To test the fix:
1. Start UniMe and select Ferris's profile
2. Reload UniMe --> UniMe should successfully reload Ferris's profile (previously this is when UniMe would redirect to the Welcome page)

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
