### PR TITLE
ci: adjust installed Ubuntu packages

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -53,7 +53,7 @@ jobs:
         working-directory: ./unime/src-tauri
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libsoup-3.0 javascriptcoregtk-4.1 webkit2gtk-4.1
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Format
         working-directory: ./unime/src-tauri
@@ -101,7 +101,7 @@ jobs:
         working-directory: ./identity-wallet
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libsoup-3.0 javascriptcoregtk-4.1 webkit2gtk-4.1
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Format
         working-directory: ./identity-wallet


### PR DESCRIPTION
# Description of change
With Ubuntu 24.04, we get the following error when installing dependencies: `E: Unable to locate package libwebkit2gtk-4.0-dev`.
According to [the Tauri documentation on GitHub pipelines](https://tauri.app/distribute/pipelines/github/#example-workflow), the usage of this package is replaced with a newer version.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
