### PR TITLE
chore: upgrade `@melt-ui/svelte` to v0.86.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,10 +43,10 @@ importers:
         version: 2.0.12
       '@melt-ui/pp':
         specifier: ^0.3.0
-        version: 0.3.2(@melt-ui/svelte@0.83.0(svelte@4.2.19))(svelte@4.2.19)
+        version: 0.3.2(@melt-ui/svelte@0.86.2(svelte@4.2.19))(svelte@4.2.19)
       '@melt-ui/svelte':
-        specifier: ^0.83.0
-        version: 0.83.0(svelte@4.2.19)
+        specifier: ^0.86.2
+        version: 0.86.2(svelte@4.2.19)
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
         version: 3.0.8(@sveltejs/kit@2.5.26(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.5.0)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.5.0)))
@@ -526,8 +526,8 @@ packages:
       '@melt-ui/svelte': '>= 0.29.0'
       svelte: ^3.55.0 || ^4.0.0 || ^5.0.0-next.1
 
-  '@melt-ui/svelte@0.83.0':
-    resolution: {integrity: sha512-E7QT+8YSftz+Hdk1W0hNR3f+cnaF2COMWkStn+2u4vk0RO1I9mXRJl+bJD6uhYaH146oxEB+5elu/ABbv6rpsA==}
+  '@melt-ui/svelte@0.86.2':
+    resolution: {integrity: sha512-wRVN603oIt1aXvx2QRmKqVDJgTScSvr/WJLLokkD8c4QzHgn6pfpPtUKmhV6Dvkk+OY89OG/1Irkd6ouA50Ztw==}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.118
 
@@ -3086,14 +3086,14 @@ snapshots:
       pako: 2.1.0
       resize-observer-polyfill: 1.5.1
 
-  '@melt-ui/pp@0.3.2(@melt-ui/svelte@0.83.0(svelte@4.2.19))(svelte@4.2.19)':
+  '@melt-ui/pp@0.3.2(@melt-ui/svelte@0.86.2(svelte@4.2.19))(svelte@4.2.19)':
     dependencies:
-      '@melt-ui/svelte': 0.83.0(svelte@4.2.19)
+      '@melt-ui/svelte': 0.86.2(svelte@4.2.19)
       estree-walker: 3.0.3
       magic-string: 0.30.11
       svelte: 4.2.19
 
-  '@melt-ui/svelte@0.83.0(svelte@4.2.19)':
+  '@melt-ui/svelte@0.86.2(svelte@4.2.19)':
     dependencies:
       '@floating-ui/core': 1.6.7
       '@floating-ui/dom': 1.6.10

--- a/unime/package.json
+++ b/unime/package.json
@@ -23,7 +23,7 @@
     "@iconify-json/ph": "^1.2.0",
     "@lottiefiles/lottie-player": "^2.0.12",
     "@melt-ui/pp": "^0.3.0",
-    "@melt-ui/svelte": "^0.83.0",
+    "@melt-ui/svelte": "^0.86.2",
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.5.26",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",


### PR DESCRIPTION
# Description of change

This is an upgrade of Melt UI, the foundation for most our custom components. Since we don't have end-to-end tests in Tauri, it is necessary to manually test as much of our app surface as possible.

## Links to any relevant issues

- Fixes #477.

## How the change has been tested

Test the following flows with the desktop version. Even better if you can deploy UniMe to your phone. Flows to test:

- Set up a new profile.
- Go through https://ministerie-van-defensie.dev.impierce.com/ (minus 8vance).
- Check out one e-commerce demo, e.g. https://deonlinedrogist.co.nl/.

Explore as much as possible side paths, e.g. tap on a credential, tap on an issuer, tap on activity etc.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
