### PR TITLE
ci: replace cargo test with cargo nextest

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -42,12 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Rust stable
-        # TODO Set back to @stable (workaround for #224).
-        # uses: dtolnay/rust-toolchain@1.77.2 fails because it does not include rustfmt.
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.77.2
-          components: clippy, rustfmt
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         working-directory: ./unime/src-tauri
@@ -55,6 +50,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          args: --locked
+   
       - name: Format
         working-directory: ./unime/src-tauri
         run: cargo fmt -- --check
@@ -82,7 +83,7 @@ jobs:
 
       - name: Test
         working-directory: ./unime/src-tauri
-        run: cargo test
+        run: cargo nextest run --retries 2
 
   identity_wallet:
     runs-on: ubuntu-latest
@@ -91,17 +92,19 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Rust stable
-        # TODO See comment above.
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.77.2
-          components: clippy, rustfmt
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         working-directory: ./identity-wallet
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          args: --locked
 
       - name: Format
         working-directory: ./identity-wallet
@@ -113,4 +116,4 @@ jobs:
 
       - name: Test
         working-directory: ./identity-wallet
-        run: cargo test
+        run: cargo nextest run --retries 2

--- a/identity-wallet/src/command.rs
+++ b/identity-wallet/src/command.rs
@@ -33,7 +33,7 @@ pub(crate) async fn reduce(state: AppState, action: Action) -> Result<AppState, 
 }
 
 // This value is based on an estimated guess. Can be adjusted in case lower/higher timeouts are desired.
-const TIMEOUT_SECS: u64 = 10;
+const TIMEOUT_SECS: u64 = 30;
 
 /// This function is used to prevent deadlocks in the backend. It will sleep for a certain amount of time and then return.
 async fn await_timeout() {

--- a/identity-wallet/src/state/actions.rs
+++ b/identity-wallet/src/state/actions.rs
@@ -21,6 +21,7 @@ pub fn listen<T: ActionTrait + Clone>(action: Action) -> Option<T> {
     action.downcast_arc::<T>().ok().map(|action| (*action).clone())
 }
 
+#[allow(clippy::empty_line_after_doc_comments)]
 /// Below is an example of how to add an action to the app
 ///
 /// Example:

--- a/identity-wallet/src/state/common/mod.rs
+++ b/identity-wallet/src/state/common/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_cancel_user_flow() {
         let current_user_prompt = Some(CurrentUserPrompt::ShareCredentials {
             client_name: "Impierce Technologies".to_string(),
@@ -58,6 +59,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_reset_state() {
         let mut app_state = AppState {
             profile_settings: ProfileSettings {

--- a/identity-wallet/src/state/credentials/reducers/delete_credential.rs
+++ b/identity-wallet/src/state/credentials/reducers/delete_credential.rs
@@ -77,6 +77,7 @@ mod tests {
     use crate::stronghold::StrongholdManager;
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_credential_is_removed_from_appstate_and_from_stronghold_and_image_is_deleted() {
         let uuid = Uuid::new_v4();
 

--- a/identity-wallet/src/state/did/validate_domain_linkage.rs
+++ b/identity-wallet/src/state/did/validate_domain_linkage.rs
@@ -215,6 +215,7 @@ mod tests {
     const LINKED_DID_JWT: &str = "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa29USHNnTk5yYnk4SnpDTlExaVJMeVc1UVE2UjhYdXU2QUE4aWdHck1WUFVNI3o2TWtvVEhzZ05OcmJ5OEp6Q05RMWlSTHlXNVFRNlI4WHV1NkFBOGlnR3JNVlBVTSJ9.eyJleHAiOjE3NjQ4NzkxMzksImlzcyI6ImRpZDprZXk6ejZNa29USHNnTk5yYnk4SnpDTlExaVJMeVc1UVE2UjhYdXU2QUE4aWdHck1WUFVNIiwibmJmIjoxNjA3MTEyNzM5LCJzdWIiOiJkaWQ6a2V5Ono2TWtvVEhzZ05OcmJ5OEp6Q05RMWlSTHlXNVFRNlI4WHV1NkFBOGlnR3JNVlBVTSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly9pZGVudGl0eS5mb3VuZGF0aW9uLy53ZWxsLWtub3duL2RpZC1jb25maWd1cmF0aW9uL3YxIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmtleTp6Nk1rb1RIc2dOTnJieThKekNOUTFpUkx5VzVRUTZSOFh1dTZBQThpZ0dyTVZQVU0iLCJvcmlnaW4iOiJpZGVudGl0eS5mb3VuZGF0aW9uIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyNS0xMi0wNFQxNDoxMjoxOS0wNjowMCIsImlzc3VhbmNlRGF0ZSI6IjIwMjAtMTItMDRUMTQ6MTI6MTktMDY6MDAiLCJpc3N1ZXIiOiJkaWQ6a2V5Ono2TWtvVEhzZ05OcmJ5OEp6Q05RMWlSTHlXNVFRNlI4WHV1NkFBOGlnR3JNVlBVTSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJEb21haW5MaW5rYWdlQ3JlZGVudGlhbCJdfX0.aUFNReA4R5rcX_oYm3sPXqWtso_gjPHnWZsB6pWcGv6m3K8-4JIAvFov3ZTM8HxPOrOL17Qf4vBFdY9oK0HeCQ";
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn when_no_well_known_then_return_validation_status_unknown() {
         let mock_server = MockServer::start().await;
 
@@ -225,6 +226,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn when_well_known_only_contains_json_ld_credential_then_return_unknown() {
         let mock_server = MockServer::start().await;
 
@@ -258,6 +260,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn when_well_known_contains_json_ld_and_jwt_then_remove_json_ld_during_fetch() {
         // Mocking a `DomainLinkageCredential` in a local test is difficult since the `mock_server` does not have an actual domain.
         // We thereby only test if `fetch_configuration()` builds a `DomainLinkageConfiguration` that could be verified.
@@ -285,6 +288,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn when_well_known_contains_unexpected_did_then_return_failure() {
         let mock_server = MockServer::start().await;
 
@@ -319,6 +323,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn successfully_ignores_url_parts_other_than_origin() {
         let mock_server = MockServer::start().await;
 

--- a/identity-wallet/src/state/did/validate_domain_linkage.rs
+++ b/identity-wallet/src/state/did/validate_domain_linkage.rs
@@ -146,7 +146,7 @@ async fn fetch_configuration(mut url: url::Url) -> Result<DomainLinkageConfigura
     // 2. Fetch the resource
     let response = reqwest::get(url.clone())
         .await
-        .map_err(|_| format!("failed to get response from resource url: {}", url))?;
+        .map_err(|err| format!("failed to get response from resource url: {}, err: {err}", url))?;
 
     // 3. Parse to JSON value (mutable)
     let mut json = response

--- a/identity-wallet/src/state/did/validate_linked_verifiable_presentations.rs
+++ b/identity-wallet/src/state/did/validate_linked_verifiable_presentations.rs
@@ -694,6 +694,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn validate_linked_verifiable_presentations_successfully_validates_multiple_presentations() {
         let mut holder = TestEntity::new().await;
 
@@ -785,6 +786,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn validate_linked_verifiable_presentations_successfully_considers_missing_issuer_domain_linkage() {
         let mut holder = TestEntity::new().await;
 
@@ -831,6 +833,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn get_linked_verifiable_presentation_urls_successfully_retrieves_urls() {
         let mut holder = TestEntity::new().await;
 
@@ -872,6 +875,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn get_validated_linked_credential_data_succesfully_returns_linked_verifiable_credential_data() {
         let mut issuer = TestEntity::new().await;
 
@@ -929,6 +933,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn get_validated_linked_domains_returns_only_succesfully_validated_linked_domains() {
         let mut issuer1 = TestEntity::new().await;
 

--- a/identity-wallet/src/state/mod.rs
+++ b/identity-wallet/src/state/mod.rs
@@ -32,6 +32,7 @@ use std::{collections::VecDeque, pin::Pin};
 use trust_list::TrustLists;
 use ts_rs::TS;
 
+#[allow(clippy::empty_line_after_doc_comments)]
 /// The AppState is the main state of the application shared between the backend and the frontend.
 /// We have structured the state and its operations following the redux pattern.
 /// To safeguard this pattern we have introduced the FeatTrait, ActionTrait and a macro_rule for the Reducers.
@@ -39,7 +40,7 @@ use ts_rs::TS;
 /// This is to ensure that the state is serializable/deserializable and cloneable among other things.
 /// All actions have to implement the ActionTrait.
 /// This ensures that all actions have at least one reducer, implement a debug method,
-///  and are downcastable (necessary when receiving the action from the frontend)
+/// and are downcastable (necessary when receiving the action from the frontend)
 /// The reducers are paired with the actions using our macro_rule.
 /// This ensures that all reducers have the same signature and therefore follow the redux pattern and our error handling.
 /// All the above goes for extensions (values) which are added to the extensions field.

--- a/identity-wallet/src/state/profile_settings/mod.rs
+++ b/identity-wallet/src/state/profile_settings/mod.rs
@@ -139,6 +139,7 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_set_locale() {
         let mut app_state = AppState::default();
 
@@ -150,6 +151,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_update_profile_settings() {
         let active_profile = Profile {
             name: "Ferris".to_string(),

--- a/identity-wallet/src/state/profile_settings/reducers/update_sorting_preference.rs
+++ b/identity-wallet/src/state/profile_settings/reducers/update_sorting_preference.rs
@@ -184,6 +184,7 @@ mod tests {
     // Currently we #[PartialEq(ignore)] the metadata.date_added field since it will fail many other tests.
     // The json files are static but some tests create new credentials and the date_added field will be added at this time.
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_credentials_update_sorting_setting_date_added() {
         let state = AppState::default();
         let action = Arc::new(UpdateSortingPreference {
@@ -207,6 +208,7 @@ mod tests {
     // sort_credentials tests //
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_credentials_sorting_name_az() {
         let state = init_credential_names("C".to_string(), "A".to_string(), "B".to_string());
         let action = Arc::new(UpdateSortingPreference { ..Default::default() });
@@ -225,6 +227,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_credentials_sorting_name_az_reverse() {
         let state = init_credential_names("C".to_string(), "A".to_string(), "B".to_string());
         let action = Arc::new(UpdateSortingPreference {
@@ -247,6 +250,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_credentials_sorting_issue_reverse() {
         let state = init_credential_issuance_dates(
             "2022-00-00T00:00:00Z".to_string(),
@@ -279,6 +283,7 @@ mod tests {
     // sort_connections tests //
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_connections_sorting_name_az_reverse() {
         let state = init_connection_names("Gym".to_string(), "Work".to_string(), "School".to_string());
         let action = Arc::new(UpdateSortingPreference {
@@ -304,6 +309,7 @@ mod tests {
     // In fact, the {last_interacted, reverse: true} is the same as {first_interacted, reverse:false}.
     // For this reason the reverse button will disabled for these sorting options.
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_connections_sorting_first_interact() {
         let state = init_connection_interactions(
             "2019-00-00T00:00:00Z".to_string(),
@@ -335,6 +341,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_connections_sorting_last_interact() {
         let state = init_connection_interactions(
             "2020-00-00T00:00:00Z".to_string(),

--- a/identity-wallet/src/state/search/reducers/search_query.rs
+++ b/identity-wallet/src/state/search/reducers/search_query.rs
@@ -77,6 +77,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_search_query() {
         let mut app_state = app_state();
 

--- a/identity-wallet/src/state/trust_list/reducers/add_entry.rs
+++ b/identity-wallet/src/state/trust_list/reducers/add_entry.rs
@@ -49,6 +49,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_add_trust_list_entry() {
         let mut state = AppState::default();
         let default_trust_list = TrustList {

--- a/identity-wallet/src/state/trust_list/reducers/add_trust_list.rs
+++ b/identity-wallet/src/state/trust_list/reducers/add_trust_list.rs
@@ -37,6 +37,7 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_trust_list_add() {
         let state = AppState::default();
 

--- a/identity-wallet/src/state/trust_list/reducers/delete_entry.rs
+++ b/identity-wallet/src/state/trust_list/reducers/delete_entry.rs
@@ -42,6 +42,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_delete_trust_list_entry() {
         let mut state = AppState::default();
         let default_trust_list = TrustList {

--- a/identity-wallet/src/state/trust_list/reducers/delete_trust_list.rs
+++ b/identity-wallet/src/state/trust_list/reducers/delete_trust_list.rs
@@ -36,6 +36,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_trust_list_delete() {
         let mut state = AppState::default();
         let default_trust_list = TrustList {

--- a/identity-wallet/src/state/trust_list/reducers/edit_entry.rs
+++ b/identity-wallet/src/state/trust_list/reducers/edit_entry.rs
@@ -47,6 +47,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_edit_trust_list_entry() {
         let mut state = AppState::default();
         let default_trust_list = TrustList {

--- a/identity-wallet/src/state/trust_list/reducers/edit_trust_list.rs
+++ b/identity-wallet/src/state/trust_list/reducers/edit_trust_list.rs
@@ -43,6 +43,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_trust_list_edit() {
         let mut state = AppState::default();
         let default_trust_list = TrustList {

--- a/identity-wallet/src/state/trust_list/reducers/toggle_entry.rs
+++ b/identity-wallet/src/state/trust_list/reducers/toggle_entry.rs
@@ -43,6 +43,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_toggletrust_list_entry() {
         let mut state = AppState::default();
         let default_trust_list = TrustList {

--- a/identity-wallet/src/state/user_journey/mod.rs
+++ b/identity-wallet/src/state/user_journey/mod.rs
@@ -15,6 +15,7 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_cancel_user_journey() {
         let mut app_state = AppState {
             user_journey: Some(json!("Some Journey")),


### PR DESCRIPTION
# Description of change
As title.

[Nextest](https://nexte.st/) is a widely used testing tool for Rust that offers better performance and extra features over the standard `cargo test` tool. 

One feature is that it can detect flaky tests. We do currently have two flaky tests:
- `test_qr_code_scanned_handle_siopv2_authorization_request`
- `verifier_successfully_verifies_eddsa_signed_data`

Example of a flaky test messing up our testing: https://github.com/impierce/identity-wallet/actions/runs/13316403841/job/37191398477

Example of a (local) test run with `nextest` containing a flaky test:
![image](https://github.com/user-attachments/assets/51d9716b-752f-4d3e-a97c-db42e11ddaa2)

As can be seen, the test is marked as flaky, but all tests still pass.

## Links to any relevant issues
Failing job: https://github.com/impierce/identity-wallet/actions/runs/13316403841/job/37191398477

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
