### PR TITLE
style: allow empty line after doc comments

### DIFF
--- a/identity-wallet/src/state/actions.rs
+++ b/identity-wallet/src/state/actions.rs
@@ -21,6 +21,7 @@ pub fn listen<T: ActionTrait + Clone>(action: Action) -> Option<T> {
     action.downcast_arc::<T>().ok().map(|action| (*action).clone())
 }
 
+#[allow(clippy::empty_line_after_doc_comments)]
 /// Below is an example of how to add an action to the app
 ///
 /// Example:

--- a/identity-wallet/src/state/mod.rs
+++ b/identity-wallet/src/state/mod.rs
@@ -32,6 +32,7 @@ use std::{collections::VecDeque, pin::Pin};
 use trust_list::TrustLists;
 use ts_rs::TS;
 
+#[allow(clippy::empty_line_after_doc_comments)]
 /// The AppState is the main state of the application shared between the backend and the frontend.
 /// We have structured the state and its operations following the redux pattern.
 /// To safeguard this pattern we have introduced the FeatTrait, ActionTrait and a macro_rule for the Reducers.
@@ -39,7 +40,7 @@ use ts_rs::TS;
 /// This is to ensure that the state is serializable/deserializable and cloneable among other things.
 /// All actions have to implement the ActionTrait.
 /// This ensures that all actions have at least one reducer, implement a debug method,
-///  and are downcastable (necessary when receiving the action from the frontend)
+/// and are downcastable (necessary when receiving the action from the frontend)
 /// The reducers are paired with the actions using our macro_rule.
 /// This ensures that all reducers have the same signature and therefore follow the redux pattern and our error handling.
 /// All the above goes for extensions (values) which are added to the extensions field.


### PR DESCRIPTION
# Description of change
Some Cargo Clippy lint checks were failing due to empty lines after doc comments. This PR silences those warning using:
```rust
#[allow(clippy::empty_line_after_doc_comments)]
```

## Links to any relevant issues
n/a

## How the change has been tested
Validated that:
```yaml
cargo clippy --all-targets --all-features -- -D warnings
```
does not result in clippy warnings anymore

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
