### PR TITLE
test: use reserved testing domain `example.test` (RFC 2606)

### DIFF
--- a/unime/src-tauri/tests/fixtures/actions/qr_scanned_id_token.json
+++ b/unime/src-tauri/tests/fixtures/actions/qr_scanned_id_token.json
@@ -1,6 +1,6 @@
 {
   "type": "[QR Code] Scanned",
   "payload": {
-    "form_urlencoded": "openid://?client_id=did%3Akey%3Az6Mkm9yeuZK7inXBNjnNH3vAs9uUjqfy3mfNoKBKsKBrv8Tb&client_metadata=%7B%22id_token_signed_response_alg%22%3A%22EdDSA%22%2C%22subject_syntax_types_supported%22%3A%5B%22did%3Akey%22%5D%7D&nonce=nonce&redirect_uri=https%3A%2F%2Fexample.com%2F&response_type=id_token&scope=openid"
+    "form_urlencoded": "openid://?client_id=did%3Akey%3Az6Mkm9yeuZK7inXBNjnNH3vAs9uUjqfy3mfNoKBKsKBrv8Tb&client_metadata=%7B%22id_token_signed_response_alg%22%3A%22EdDSA%22%2C%22subject_syntax_types_supported%22%3A%5B%22did%3Akey%22%5D%7D&nonce=nonce&redirect_uri=https%3A%2F%2Fexample.test%2F&response_type=id_token&scope=openid"
   }
 }

--- a/unime/src-tauri/tests/fixtures/states/accept_connection.json
+++ b/unime/src-tauri/tests/fixtures/states/accept_connection.json
@@ -8,13 +8,13 @@
   },
   "current_user_prompt": {
     "type": "accept-connection",
-    "client_name": "example.com",
+    "client_name": "example.test",
     "logo_uri": null,
-    "redirect_uri": "https://example.com/",
+    "redirect_uri": "https://example.test/",
     "previously_connected": false,
     "domain_validation": {
       "status": "Unknown",
-      "message": "Error while fetching configuration: failed to parse response into JSON value"
+      "message": "Error while fetching configuration: failed to get response from resource url: https://example.test/.well-known/did-configuration.json"
     },
     "linked_verifiable_presentations": []
   }

--- a/unime/src-tauri/tests/fixtures/states/did_redirect_me.json
+++ b/unime/src-tauri/tests/fixtures/states/did_redirect_me.json
@@ -2,8 +2,8 @@
   "connections": [
     {
       "id": "c0f1be09f33c331ee001a09e1515ba70022a102b30ebad7f15f8e6a9017e177c",
-      "name": "example.com",
-      "url": "example.com",
+      "name": "example.test",
+      "url": "example.test",
       "verified": false,
       "first_interacted": "2024-03-15T01:16:28.712260354+00:00",
       "last_interacted": "2024-03-15T01:16:28.712260354+00:00"
@@ -23,7 +23,7 @@
   "history": [
     {
       "connection_id": "c0f1be09f33c331ee001a09e1515ba70022a102b30ebad7f15f8e6a9017e177c",
-      "connection_name": "example.com",
+      "connection_name": "example.test",
       "event_type": "ConnectionAdded",
       "date": "2024-03-15T01:17:34.692691163+00:00",
       "credentials": []

--- a/unime/src-tauri/tests/tests/qr_code_scanned.rs
+++ b/unime/src-tauri/tests/tests/qr_code_scanned.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+
 use crate::common::json_example;
 use crate::common::{
     assert_state_update::{assert_state_update, setup_state_file},
     test_managers,
 };
+use identity_wallet::state::actions::ActionTrait;
 use identity_wallet::state::profile_settings::AppTheme;
+use identity_wallet::state::user_prompt::CurrentUserPrompt;
 use identity_wallet::state::{
     actions::Action,
     core_utils::CoreUtils,
@@ -14,6 +18,8 @@ use identity_wallet::state::{
 
 use serde_json::json;
 use tokio::sync::Mutex;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
 #[serial_test::serial]
@@ -27,10 +33,38 @@ async fn test_qr_code_scanned_handle_siopv2_authorization_request() {
         theme: AppTheme::System,
     });
 
+    // Start a mock server to respond to the domain linkage request.
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/foobar"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "foo": "bar" })))
+        .mount(&mock_server)
+        .await;
+
     // Deserializing the Appstates and Actions from the accompanying json files.
-    let state1 = json_example::<AppState>("tests/fixtures/states/accept_connection.json");
+    let mut state1 = json_example::<AppState>("tests/fixtures/states/accept_connection.json");
+    let validation_result = serde_json::from_str(&format!(
+        "{{\"status\":\"Unknown\",\"name\":null,\"logo_uri\":null,\"issuance_date\":null,\"message\":\"Error while fetching configuration: failed to get response from resource url: https://{}/.well-known/did-configuration.json\"}}",
+        mock_server.address()
+    ))
+    .unwrap();
+    let current_user_prompt = CurrentUserPrompt::AcceptConnection {
+        client_name: "127.0.0.1".to_string(),
+        logo_uri: None,
+        // TODO: scheme is a problem in local environment: we have to use http (where https is inferred)
+        redirect_uri: format!("http://{}/", mock_server.address()),
+        previously_connected: false,
+        domain_validation: Box::new(validation_result),
+        linked_verifiable_presentations: vec![],
+    };
+    state1.current_user_prompt = Some(current_user_prompt);
+
     let state2 = json_example::<AppState>("tests/fixtures/states/did_redirect_me.json");
-    let action1 = json_example::<Action>("tests/fixtures/actions/qr_scanned_id_token.json");
+
+    let action1: Arc<dyn ActionTrait> = Arc::new(identity_wallet::state::qr_code::actions::qrcode_scanned::QrCodeScanned {
+        form_urlencoded: format!("openid://?client_id=did%3Akey%3Az6Mkm9yeuZK7inXBNjnNH3vAs9uUjqfy3mfNoKBKsKBrv8Tb&client_metadata=%7B%22id_token_signed_response_alg%22%3A%22EdDSA%22%2C%22subject_syntax_types_supported%22%3A%5B%22did%3Akey%22%5D%7D&nonce=nonce&redirect_uri=https%3A%2F%2F{}%2F&response_type=id_token&scope=openid", mock_server.address())
+    });
+
     let action2 = json_example::<Action>("tests/fixtures/actions/authenticate_connect_accept.json");
 
     let container = AppStateContainer(Mutex::new(AppState {


### PR DESCRIPTION
# Description of change

### Error message

The test `test_qr_code_scanned_handle_siopv2_authorization_request` runs successfully locally, but fails in CI.

Expected: `Error while fetching configuration: failed to parse response into JSON value`
==> **The external system could be reached, but the response cannot be parsed into a JSON value**

Actual: `Error while fetching configuration: failed to get response from resource url: https://example.com/.well-known/did-configuration.json`
==> **The external system could not be reached at all**

### Root cause

One of the problems for this inconsistency is that an actually existing domain is used for many integration tests: `example.com`. It thereby needs to be treated as "external dependency" - even if it's just for testing purposes.
Depending on whether the test execution environment has internet access or not, the HTTP responses when trying to fetch from that resource are differing.

### Solution

There are [TLDs specifically reserved for testing](https://www.rfc-editor.org/rfc/rfc2606.html#section-2), such as `.test` or `.example`.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
