### PR TITLE
fix: relative time calculations and tests

### DIFF
--- a/unime/src/lib/utils.test.ts
+++ b/unime/src/lib/utils.test.ts
@@ -58,6 +58,8 @@ describe('formatDateTime function', () => {
 });
 
 describe('formatRelativeDateTime function', () => {
+  // Test a random sample of different relative times with different locales.
+
   test('1 min ago en-US', () => {
     const now = new Date();
     const oneMinuteAgo = new Date(now.setMinutes(now.getMinutes() - 1));
@@ -103,7 +105,9 @@ describe('formatRelativeDateTime function', () => {
   test('1 month ago nl-NL', () => {
     const now = new Date();
     const oneMonthAgo = new Date(now.setMonth(now.getMonth() - 1));
-    expect(formatRelativeDateTime(oneMonthAgo.toISOString(), 'nl-NL')).toEqual('Vorige maand');
+    const result = formatRelativeDateTime(oneMonthAgo.toISOString(), 'nl-NL');
+    // `result` can differ depending on which month the test runs (February is a short month).
+    expect(['Vorige maand', '4 weken geleden']).toContain(result);
   });
 
   test('2 months ago nl-NL', () => {

--- a/unime/src/lib/utils.ts
+++ b/unime/src/lib/utils.ts
@@ -83,19 +83,26 @@ export function formatDateTime(isoDate: string, locale: Locale, test = false) {
 }
 
 export function formatRelativeDateTime(isoDate: string, locale: Locale) {
-  // 1 min, 1 hour, 1 day, 1 week, 1 month, 1 year.today
+  const date = new Date(isoDate);
+  const now = new Date();
+
+  const diffInSeconds = (date.getTime() - now.getTime()) / 1000;
+
+  // Thresholds in seconds: 1 min, 1 hour, 1 day, 1 week, 1 month, 1 year.
   const thresholds = [60, 3600, 86400, 86400 * 7, 86400 * 30, 86400 * 365, Infinity];
+
   const units: Intl.RelativeTimeFormatUnit[] = ['second', 'minute', 'hour', 'day', 'week', 'month', 'year'];
 
-  const diffInSeconds = (Date.now() - new Date(isoDate).getTime()) / 1000;
-
   // Determine the threshold to use.
-  const index = thresholds.findIndex((threshold) => threshold > diffInSeconds);
+  const index = thresholds.findIndex((threshold) => Math.abs(diffInSeconds) < threshold);
   const divisor = index ? thresholds[index - 1] : 1;
 
-  const relativeDateTime = new Intl.RelativeTimeFormat(locale, {
+  const relativeFormatter = new Intl.RelativeTimeFormat(locale, {
     numeric: 'auto',
-  }).format(-1 * Math.floor(diffInSeconds / divisor), units[index]);
+  });
+
+  // Use Math.round for more accurate relative time.
+  const relativeDateTime = relativeFormatter.format(Math.round(diffInSeconds / divisor), units[index]);
 
   // Capitalize the first character.
   return relativeDateTime.charAt(0).toUpperCase() + relativeDateTime.slice(1);


### PR DESCRIPTION
# Description of change

Two unit tests testing `formatRelativeDateTime` failed:

1. The "1 month ago" test came back as "4 weeks ago" instead of "1 month ago". This was due to February 2025 having only 28 days. This is correct and I fixed the unit test to allow two results.
2. The "2 months ago" test came back as "last month". This was due to a rounding error. I now use `Math.round` instead of `Math.floor`.

## Links to any relevant issues

- Fixes #510.

Be sure to reference any related issues by adding `fixes issue #`.

## How the change has been tested

Vitest unit tests shouls pass.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
