### PR TITLE
ci: turn on `svelte-check`

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Test
         run: pnpm test
 
-      - name: svelte-check
+      - name: Check
         run: pnpm check
 
   unime_core:

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["dev"]
 
+env:
+  PUBLIC_DEV_MODE_MENU_EXPANDED: false
+  PUBLIC_STYLE_SAFE_AREA_INSETS: false
+
 jobs:
   unime_frontend:
     runs-on: ubuntu-latest
@@ -70,9 +74,6 @@ jobs:
       - name: Build frontend
         # Otherwise linting will fail with error: The `distDir` configuration is set to `"../build"` but this path doesn't exist.
         run: pnpm i --frozen-lockfile && pnpm build
-        env:
-          PUBLIC_DEV_MODE_MENU_EXPANDED: false
-          PUBLIC_STYLE_SAFE_AREA_INSETS: false
 
       - name: Lint
         working-directory: ./unime/src-tauri

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: svelte-check
+        run: pnpm check
+
   unime_core:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Description of change

Run `svelte-check` during CI.

## Links to any relevant issues

- Fixes #184.

## How the change has been tested

CI should run without errors.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
