### PR TITLE
feat: enable locale `en-GB`, refine base `en` translations

### DIFF
--- a/unime/src/i18n/en-GB/index.ts
+++ b/unime/src/i18n/en-GB/index.ts
@@ -4,7 +4,7 @@ import en from '../en';
 import type { Translation } from '../i18n-types';
 
 const en_GB = extendLanguage(en, {
-ONBOARDING: {
+  ONBOARDING: {
     CUSTOMIZE: {
       NAVBAR_TITLE: 'Customisation',
     },
@@ -19,19 +19,19 @@ ONBOARDING: {
         DESCRIPTION:
           "We do not track your actions behind the scenes. Full stop. Not for testing or any other reasons. That's our pledge. We also do not collect any anonymous device information or usage statistics. That decision makes developing the app a bit harder for us, but we believe it is the right decision.",
       },
-    }, 
+    },
   },
-  SCAN:{
-    CONNECTION_REQUEST:{
-      DESCRIPTION: 'Only accept new connections that you recognise and trust'
-    }
+  SCAN: {
+    CONNECTION_REQUEST: {
+      DESCRIPTION: 'Only accept new connections that you recognise and trust',
+    },
   },
   ME: {
     FAVORITES: 'My favourites',
   },
-ERROR: {
-  TITLE: 'Oh dear!',
-}
+  ERROR: {
+    TITLE: 'Oh dear!',
+  },
 }) satisfies Translation;
 
 export default en_GB;

--- a/unime/src/i18n/en-GB/index.ts
+++ b/unime/src/i18n/en-GB/index.ts
@@ -4,11 +4,13 @@ import en from '../en';
 import type { Translation } from '../i18n-types';
 
 const en_GB = extendLanguage(en, {
-  ONBOARDING: {
+ONBOARDING: {
     CUSTOMIZE: {
       NAVBAR_TITLE: 'Customisation',
     },
     PLEDGE: {
+      TITLE_1: 'No dodgy',
+      TITLE_2: 'dealings',
       ITEM_1: {
         DESCRIPTION:
           'Your data belongs to you and only you decide who you share it with. Full stop. In fact, your data never even touches any of our systems - unless you opt-in to one of the cloud storage options.',
@@ -17,11 +19,19 @@ const en_GB = extendLanguage(en, {
         DESCRIPTION:
           "We do not track your actions behind the scenes. Full stop. Not for testing or any other reasons. That's our pledge. We also do not collect any anonymous device information or usage statistics. That decision makes developing the app a bit harder for us, but we believe it is the right decision.",
       },
-    },
+    }, 
+  },
+  SCAN:{
+    CONNECTION_REQUEST:{
+      DESCRIPTION: 'Only accept new connections that you recognise and trust'
+    }
   },
   ME: {
     FAVORITES: 'My favourites',
   },
+ERROR: {
+  TITLE: 'Oh dear!',
+}
 }) satisfies Translation;
 
 export default en_GB;

--- a/unime/src/i18n/en/index.ts
+++ b/unime/src/i18n/en/index.ts
@@ -33,7 +33,7 @@ const en = {
       NAVBAR_TITLE: 'Terms & Conditions',
       TITLE_1: "Here's the less interesting",
       TITLE_2: 'stuff',
-      SUBTITLE: 'Yeah, we know. We still recommend you read this information carefully.',
+      SUBTITLE: 'Yes, we know. We still recommend you read this information carefully.',
       T_AND_C: {
         TITLE: 'Terms & Conditions',
         DESCRIPTION: 'I have read and agree to the Terms & Conditions.',
@@ -44,7 +44,7 @@ const en = {
         FULL: `Welcome to Impierce Technologies B.V. (“we,” “us,” or “our”). These Terms & Conditions (“Terms”) govern your access to the UniMe - Identity Wallet application (“Service”). By accessing or using our Service, you agree to be bound by these Terms. If you do not agree with any part of these Terms, please do not use our Service.
 
 Acceptance of Terms
-By downloading, accessing, or using our Service, you confirm that you have read, understood, and agree to these Terms and our Privacy Policy. If you are using the Service on behalf of an organization, you represent that you have the authority to bind that organization to these Terms.
+By downloading, accessing, or using our Service, you confirm that you have read, understood, and agree to these Terms and our Privacy Policy. If you are using the Service on behalf of an organization, you represent that you have the authbeority to bind that organization to these Terms.
 
 
 User Responsibilities
@@ -318,7 +318,7 @@ By using our Service, you acknowledge that you have read, understood, and agree 
       NAVBAR_TITLE: 'Credential Offer',
       DESCRIPTION: 'is offering you the following credentials',
       ACCEPT: 'Accept credentials',
-    },
+    },C
     CONNECTION_REQUEST: {
       NAVBAR_TITLE: 'Connection Request',
       TITLE: 'New connection',
@@ -356,7 +356,7 @@ By using our Service, you acknowledge that you have read, understood, and agree 
     CONNECTION_ADDED: 'Connected to',
   },
   SEARCH: {
-    INPUT_PLACEHOLDER: 'Look for something',
+    INPUT_PLACEHOLDER: 'Search for something',
     NO_QUERY: {
       TITLE: 'What shall we search for?',
       DESCRIPTION: 'Search for any of your credentials and badges here.',

--- a/unime/src/i18n/en/index.ts
+++ b/unime/src/i18n/en/index.ts
@@ -44,7 +44,7 @@ const en = {
         FULL: `Welcome to Impierce Technologies B.V. (“we,” “us,” or “our”). These Terms & Conditions (“Terms”) govern your access to the UniMe - Identity Wallet application (“Service”). By accessing or using our Service, you agree to be bound by these Terms. If you do not agree with any part of these Terms, please do not use our Service.
 
 Acceptance of Terms
-By downloading, accessing, or using our Service, you confirm that you have read, understood, and agree to these Terms and our Privacy Policy. If you are using the Service on behalf of an organization, you represent that you have the authbeority to bind that organization to these Terms.
+By downloading, accessing, or using our Service, you confirm that you have read, understood, and agree to these Terms and our Privacy Policy. If you are using the Service on behalf of an organization, you represent that you have the authority to bind that organization to these Terms.
 
 
 User Responsibilities
@@ -318,7 +318,7 @@ By using our Service, you acknowledge that you have read, understood, and agree 
       NAVBAR_TITLE: 'Credential Offer',
       DESCRIPTION: 'is offering you the following credentials',
       ACCEPT: 'Accept credentials',
-    },C
+    },
     CONNECTION_REQUEST: {
       NAVBAR_TITLE: 'Connection Request',
       TITLE: 'New connection',

--- a/unime/src/lib/locales.ts
+++ b/unime/src/lib/locales.ts
@@ -12,4 +12,4 @@ export const locales: {
 ];
 
 // Incomplete locales can be disabled here
-export const disabledLocales: Locale[] = ['en-GB'];
+export const disabledLocales: Locale[] = [];


### PR DESCRIPTION
# Description of change

- 2 minor translations in the base `en` (en-US) are fixed
- 4 additional translations for `en-GB` are added
- `en-GB` is removed from the disabled locales and can now be selected

(description added by @daniel-mader)

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
