### PR TITLE
refactor: replace prop `isOpen` with optional `open` store in `ActionSheet`

### DIFF
--- a/unime/src/lib/components/ActionSheet.svelte
+++ b/unime/src/lib/components/ActionSheet.svelte
@@ -1,23 +1,18 @@
 <script lang="ts">
+  import { writable, type Writable } from 'svelte/store';
   import { fade, fly } from 'svelte/transition';
 
   import { createDialog, melt } from '@melt-ui/svelte';
+
+  export let titleText = '';
+  export let descriptionText = '';
+  export let open: Writable<boolean> = writable(false);
 
   // Instead of default portal in `<body>`, we create the portal at ID `#portal` in root layout.
   // This way the ActionSheet opens within the safe area.
   const {
     elements: { trigger, overlay, content, title, description, close, portalled },
-    states: { open },
-  } = createDialog({ portal: '#portal' });
-
-  export let titleText = '';
-  export let descriptionText = '';
-
-  // Reactive open state passed in from the outside
-  export let isOpen = false;
-  $: {
-    open.set(isOpen);
-  }
+  } = createDialog({ open, portal: '#portal' });
 </script>
 
 <!--
@@ -25,6 +20,7 @@
 
   @prop titleText - The title of the dialog.
   @prop descriptionText - The description of the dialog.
+  @prop open - An optional writable store to control the component from outside.
 
   @slot trigger - The trigger element that opens the dialog.
   @slot content - The content of the dialog.

--- a/unime/src/routes/(app)/me/settings/EmojiAvatarSelect.svelte
+++ b/unime/src/routes/(app)/me/settings/EmojiAvatarSelect.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from 'svelte';
 
   import LL from '$i18n/i18n-svelte';
+  import { writable } from 'svelte/store';
 
   import { melt } from '@melt-ui/svelte';
 
@@ -13,7 +14,7 @@
 
   const dispatch = createEventDispatcher();
 
-  let emojiSelectIsOpen = false;
+  const open = writable(false);
 
   // TODO: switch to Unicode?
   let predefinedEmojis: string[][] = [
@@ -56,7 +57,7 @@
   ];
 </script>
 
-<ActionSheet titleText={$LL.SETTINGS.PROFILE.DISPLAY_PICTURE.CHANGE()} descriptionText={''} isOpen={emojiSelectIsOpen}>
+<ActionSheet titleText={$LL.SETTINGS.PROFILE.DISPLAY_PICTURE.CHANGE()} descriptionText={''} {open}>
   <button
     slot="trigger"
     class="relative flex h-24 w-24 items-center justify-center rounded-full
@@ -64,7 +65,7 @@
       {showEditButton ? 'mb-[34px]' : ''}"
     use:melt={trigger}
     let:trigger
-    on:click={() => (emojiSelectIsOpen = true)}
+    on:click={() => ($open = true)}
   >
     {#if selected}
       <span class="text-[44px]/[44px]">
@@ -95,7 +96,7 @@
               : 'border-grey dark:border-blue'}"
             on:click={() => {
               dispatch('change', emoji);
-              emojiSelectIsOpen = false;
+              $open = false;
             }}
           >
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->

--- a/unime/src/routes/welcome/LanguageSelect.svelte
+++ b/unime/src/routes/welcome/LanguageSelect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import LL from '$i18n/i18n-svelte';
+  import { writable } from 'svelte/store';
 
   import { melt } from '@melt-ui/svelte';
 
@@ -11,15 +12,15 @@
 
   $: selected = locales.find((l) => l.locale === $state?.profile_settings.locale) ?? locales.at(0)!;
 
-  let isOpen = false;
+  const open = writable(false);
 </script>
 
-<ActionSheet titleText={$LL.ONBOARDING.WELCOME.SELECT_LANGUAGE()} {isOpen}>
+<ActionSheet titleText={$LL.ONBOARDING.WELCOME.SELECT_LANGUAGE()} {open}>
   <button
     slot="trigger"
     use:melt={trigger}
     let:trigger
-    on:click={() => (isOpen = true)}
+    on:click={() => ($open = true)}
     class="flex w-fit items-center justify-center rounded-lg border border-grey bg-silver px-[15px] py-3 dark:border-blue dark:bg-navy"
   >
     <TranslateRegularIcon class="mr-3 size-6 text-primary" />
@@ -31,7 +32,7 @@
       <button
         on:click={() => {
           dispatch({ type: '[Settings] Set locale', payload: { locale: l.locale } });
-          isOpen = false;
+          $open = false;
         }}
         class="flex items-center rounded-lg border p-[10px]
           {l.locale === selected.locale ? 'border-grey bg-silver dark:border-blue dark:bg-navy' : 'border-transparent'}


### PR DESCRIPTION
# Description of change

#488 requires the `ActionSheet` to be controlled from outside the component. `ActionSheet` will be used to trigger a password prompt when turning off biometrics in the settings.

The ideal solution would be boolean `open` prop that is bound the `ActionSheet`'s internal state. This state is implemented with a Svelte store (using Melt UI). Synchronizing the prop with the store would require circular reactive statements, which Svelte 5 marks as an error.

The next best thing is to let a parent component set an `open` store, which `ActionSheet` will use to manage its state. As a side effect, the `ActionSheet`'s internal state is accessible outside and can be changed from the outside. This is suboptimal because the fact that `ActionSheet` uses a store is an implementation detail, which is now part of the component API.

## Links to any relevant issues

- Fixes #539

## How the change has been tested

Test the following routes that use `ActionSheet`:

- Onboarding workflow: Change language on the first screen.
- `/me` route (for Ferris profile): use the filter button.
- Settings: Change the profile emoticon.

## Definition of Done checklist

Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
