### PR TITLE
feat: add Finnish (`fi-FI`) and Swedish (`sv-FI`) translations

### DIFF
--- a/unime/src/i18n/fi-FI/index.ts
+++ b/unime/src/i18n/fi-FI/index.ts
@@ -1,0 +1,473 @@
+import type { BaseTranslation } from '../i18n-types';
+
+const fi_FI = {
+  ONBOARDING: {
+    WELCOME: {
+      GREETING: 'Tervetuloa',
+      WHAT_IS_UNIME_1: 'UniMe yhdistää digitaalisen maailmasi turvallisesti.',
+      WHAT_IS_UNIME_2: 'Luo uusi identiteettiprofiili aloittaaksesi.',
+      CREATE_NEW_PROFILE: 'Luo uusi profiili',
+      SELECT_LANGUAGE: 'Valitse kieli',
+    },
+    PLEDGE: {
+      NAVBAR_TITLE: 'UniMe-lupaus',
+      TITLE_1: 'Ei mitään',
+      TITLE_2: 'hämärää',
+      SUBTITLE: 'Tässä on lupauksemme sinulle.',
+      ITEM_1: {
+        TITLE: 'Emme jaa tietojasi',
+        DESCRIPTION:
+          'Tietosi kuuluvat sinulle ja vain sinä päätät kenelle jaat ne. Piste. Itse asiassa tietosi eivät koskaan koske järjestelmiämme ellei sinä erikseen valitse pilvitallennusvaihtoehtoa.',
+      },
+      ITEM_2: {
+        TITLE: 'Emme lisää seurantaa',
+        DESCRIPTION:
+          'Emme seuraa toimintaasi kulissien takana. Piste. Emme testaukseen emmekä muihin tarkoituksiin. Emme myöskään kerää anonyymejä laite- tai käyttötietoja.',
+      },
+      ITEM_3: {
+        TITLE: 'Omistat tietosi',
+        DESCRIPTION: 'On jo aika että sinä omistat jälleen omat henkilötietosi.',
+      },
+    },
+    TERMS: {
+      NAVBAR_TITLE: 'Käyttöehdot',
+      TITLE_1: 'Tässä hieman vähemmän',
+      TITLE_2: 'kiinnostavaa',
+      SUBTITLE: 'Suosittelemme silti lukemaan tiedot huolellisesti.',
+      T_AND_C: {
+        TITLE: 'Käyttöehdot',
+        DESCRIPTION: 'Olen lukenut ja hyväksyn käyttöehdot.',
+        DIALOG_TITLE: 'Impierce Technologies B.V. käyttöehdot',
+        LAST_UPDATED: 'Viimeksi päivitetty: 31. lokakuuta 2024',
+        TL_DR:
+          'Kuten missä tahansa sovelluksessa, meidän on kerrottava sinulle joukko lakiasioita. Pidämme sen tiiviinä ja selkeänä, mutta tietyt muodollisuudet ovat välttämättömiä.',
+        // Note: this translation had not been verified by a legal expert.
+        FULL: `Tervetuloa Impierce Technologies B.V.:hen ("me", "meitä" tai "meidän"). Nämä käyttöehdot ("Ehdot") säätelevät pääsyäsi UniMe - Identity Wallet -sovellukseen ("Palvelu"). Avaamalla tai käyttämällä Palvelua hyväksyt olevasi sidottu näihin Ehtoihin. Jos et hyväksy jotakin näiden Ehtojen osaa, älä käytä Palvelua.
+
+Ehtojen hyväksyminen
+Lataamalla, avaamalla tai käyttämällä Palvelua vahvistat, että olet lukenut, ymmärtänyt ja hyväksyt nämä Ehdot sekä tietosuojakäytäntömme. Jos käytät Palvelua organisaation puolesta, vakuutat, että sinulla on valtuus sitoa kyseinen organisaatio näihin Ehtoihin.
+
+Käyttäjän velvollisuudet
+Tietoturva: Olet vastuussa laitteidesi ja mahdollisten pääsytietojen (tunnisteiden) luottamuksellisuuden ja turvallisuuden säilyttämisestä. Impierce Technologies B.V. ei ole vastuussa mistään tietojesi menetyksestä tai vaarantumisesta, joka johtuu siitä, että et suojaa laitettasi.
+Lakien noudattaminen: Sitoudut käyttämään Palvelua kaikkien sovellettavien lakien ja säädösten mukaisesti.
+Tietojen paikkansapitävyys: Varmistat, että kaikki Palvelun kautta tallentamasi tai jakamasi tiedot ovat oikeita ja ajan tasalla.
+
+Tietojen omistajuus ja yksityisyys
+Ei tietojen keräämistä: Emme kerää, tallenna tai käsittele henkilötietoja UniMe-sovelluksen kautta. Kaikki identiteettitiedot pysyvät yksinomaan laitteellasi tai valitsemassasi tallennusratkaisussa.
+Käyttäjän hallitsema jakaminen: Tietojen jakaminen käynnistyy ja sitä hallitset ainoastaan sinä, ja se tapahtuu suoraan sinun ja valitsemasi osapuolen välillä. Meillä ei ole pääsyä identiteettiisi tai toimintaasi.
+Kolmansien osapuolten tietojen keruu: Huomaa, että kolmansien osapuolten alustat, kuten Apple App Store tai Google Play Store, voivat kerätä tietoja sovelluksen suorituskyvystä, käytöstä ja laitetiedoista itsenäisesti ja meistä riippumatta.
+
+Immateriaalioikeudet
+Omistus ja lisenssit: Kaikki UniMeen ja siihen liittyviin materiaaleihin kohdistuvat immateriaalioikeudet kuuluvat Impierce Technologies B.V.:lle tai sen lisenssinantajille. UniMe on kuitenkin saatavilla avoimen lähdekoodin tuotteena Apache 2.0 -lisenssillä, minkä ansiosta käyttäjät voivat käyttää, muokata ja jakea ohjelmistoa kyseisen lisenssin ehtojen mukaisesti.
+Lisenssin myöntäminen: Lataamalla tai käyttämällä UniMeä hyväksyt Apache 2.0 -lisenssin ehdot, jotka myöntävät maailmanlaajuisen, rojaltivapaan lisenssin ohjelmiston käyttöön, kopiointiin ja jakeluun asianmukaisella attribuutiolla.
+Lisätietoja varten tutustu Apache 2.0 -lisenssin täydelliseen tekstiin.
+
+Kielletyt toiminnot
+Sitoudut olemaan ryhtymättä seuraaviin:
+Luvaton pääsy: Yritykset saada luvaton pääsy Palveluun tai sen järjestelmiin.
+Häirintä: Palvelun turvallisuuden tai suorituskyvyn häiritseminen tai estäminen.
+Väärinkäyttö: Palvelun käyttäminen laittomiin, haitallisiin, petollisiin, loukkaaviin tai muihin vahingollisiin tarkoituksiin.
+
+Kolmansien osapuolten palvelut
+Palvelumme voi sisältää linkkejä tai integraatioita kolmansien osapuolten palveluihin. Emme hallitse näitä kolmansien osapuolten palveluja emmekä vastaa niiden sisällöstä tai käytännöistä. Palveluiden käyttö tapahtuu omalla riskilläsi ja niiden omien ehtojen alaisena.
+
+Vastuuvapauslausekkeet
+"Sellaisenaan"-peruste: Palvelu tarjotaan "sellaisenaan" ja "saatavuuden mukaan" ilman mitään nimenomaisia tai konkludenttisia takuita.
+Ei takuuta: Emme takaa, että Palvelu on keskeytymätön, virheetön, turvallinen tai vapaa viruksista tai muista haitallisista komponenteista.
+
+Vastuunrajoitus
+Sovellettavan lain sallimissa rajoissa Impierce Technologies B.V. ei ole vastuussa mistään epäsuorista, satunnaisista, erityisistä, seuraamuksellisista tai rangaistuksellisista vahingoista, mukaan lukien (mutta ei rajoittuen) voiton, tietojen, käytön, goodwillin tai muiden aineettomien hyötyjen menetykseen, jotka johtuvat:
+pääsystäsi Palveluun tai sen käytöstäsi tai kyvyttömyydestäsi käyttää Palvelua;
+kolmannen osapuolen toiminnasta tai sisällöstä Palvelussa;
+Palvelun kautta hankitusta sisällöstä.
+
+Korvausvelvollisuus
+Sitoudut vapauttamaan, puolustamaan ja pitämään Impierce Technologies B.V.:n, sen tytäryhtiöt sekä niiden johtajat, toimihenkilöt, työntekijät ja edustajat vahingoittumattomina kaikista vaatimuksista, vastuista, vahingoista, menetyksistä ja kustannuksista, jotka johtuvat tai liittyvät:
+pääsyysi Palveluun tai sen käyttöön;
+näiden Ehtojen rikkomiseen;
+kolmannen osapuolen oikeuksien loukkaamiseen.
+
+Ehtojen muutokset
+Voimme päivittää tai muokata näitä Ehtoja ajoittain. "Viimeksi päivitetty" -päivämäärä yläosassa osoittaa viimeisimmän muutoksen ajankohdan. Ilmoitamme olennaisista muutoksista julkaisemalla uudet Ehdot verkkosivustollamme tai Palvelussa. Jatkuva Palvelun käyttö muutosten jälkeen merkitsee hyväksyntääsi.
+
+Sovellettava laki ja toimivalta
+Näihin Ehtoihin sovelletaan Alankomaiden lakia, ja niitä tulkitaan sen mukaisesti. Mahdolliset näistä Ehdosta johtuvat tai niihin liittyvät riidat kuuluvat Alankomaiden tuomioistuinten yksinomaiseen toimivaltaan.
+
+Erottettavuus
+Jos jokin näiden Ehtojen määräys todetaan pätemättömäksi tai täytäntöönpanokelvottomaksi, jäljelle jäävät määräykset pysyvät täysin voimassa.
+
+Koko sopimus
+Nämä Ehdot yhdessä tietosuojakäytäntömme kanssa muodostavat koko sopimuksen sinun ja Impierce Technologies B.V.:n välillä Palvelun käytöstäsi.
+
+Yhteystiedot
+Kysymykset, kommentit tai huolenaiheet näihin Ehtoihin liittyen:
+Impierce Technologies B.V.
+Karekietweide 6, 3993 CD, Houten, Alankomaat
+Sähköposti: contact@impierce.com
+
+Kieli
+Näistä Ehdosta voidaan tarjota käännöksiä. Ristiriitatilanteessa englanninkielinen versio on etusijalla.
+
+Käyttämällä Palvelua vahvistat, että olet lukenut, ymmärtänyt ja hyväksyt nämä Ehdot. Impierce Technologies B.V. on sitoutunut tarjoamaan turvallisia ja yksityisyyttä kunnioittavia ratkaisuja huomioiden oikeutesi ja vapautesi.`,
+      },
+      OWNERSHIP: {
+        TITLE: 'Tietojen omistajuus',
+        DESCRIPTION: 'Ymmärrän että vastaan tiedoistani yksin.',
+      },
+    },
+    CUSTOMIZE: {
+      NAVBAR_TITLE: 'Mukautus',
+      NAME: {
+        TITLE_1: 'Aloitetaan! Valitse',
+        TITLE_2: 'profiilin nimi',
+        SUBTITLE: 'Profiilitietosi eivät koskaan poistu laitteeltasi.',
+        INPUT_PLACEHOLDER: 'Anna profiilin nimi',
+      },
+      PICTURE: {
+        TITLE_1: 'Aseta näyttö',
+        TITLE_2: 'kuva',
+        SUBTITLE: 'Tee siitä sinun.',
+      },
+    },
+    PASSWORD: {
+      NAVBAR_TITLE: 'Salasana',
+      TITLE_1: 'Aseta uusi',
+      TITLE_2: 'salasana',
+      SUBTITLE: 'Valitse vahva salasana salataksesi tietosi turvallisesti.',
+      INPUT_PLACEHOLDER: 'Anna salasana',
+      CONFIRM: {
+        NAVBAR_TITLE: 'Vahvista salasana',
+        TITLE_1: 'Vahvista uusi',
+        TITLE_2: 'salasana',
+        SUBTITLE: 'Varmistetaan että kirjoitit sen oikein.',
+        INPUT_PLACEHOLDER: 'Kirjoita salasana uudelleen',
+        MATCH: 'Salasanat täsmäävät',
+        NO_MATCH: 'Salasanat eivät täsmää',
+      },
+      BIOMETRICS: {
+        TITLE: 'Ota käyttöön {type:string}',
+        DESCRIPTION: 'Haluatko käyttää {type:string} sovelluksen avaamiseen?',
+        CONFIRM: 'Kyllä, käytä {type:string}',
+        DECIDE_LATER: 'Päätä myöhemmin',
+      },
+      COMPLETED: {
+        NAVBAR_TITLE: 'Salasana asetettu',
+        TITLE_1: 'UniMe-profiilisi on nyt',
+        TITLE_2: 'suojattu',
+        MESSAGE_1: 'Turvallinen & suojattu.',
+        MESSAGE_2: 'Hienoa työtä',
+      },
+    },
+  },
+  SETTINGS: {
+    NAVBAR_TITLE: 'Asetukset',
+    PROFILE: {
+      TITLE: 'Oma profiili',
+      PROFILE_NAME: {
+        TITLE: 'Profiilin nimi',
+        NAVBAR_TITLE: 'Vaihda profiilin nimeä',
+        INPUT_PLACEHOLDER: 'Anna profiilin nimi',
+        CONFIRM: 'Päivitä',
+      },
+      DISPLAY_PICTURE: {
+        EDIT: 'Muokkaa',
+        CHANGE: 'Valitse profiilikuva',
+        REMOVE: 'Poista',
+      },
+      DELETE_PROFILE: {
+        TITLE: 'Poista profiili',
+      },
+    },
+    APP: {
+      TITLE: 'Sovellusasetukset',
+      NAVBAR_TITLE: 'Sovellusasetukset',
+      LANGUAGE: {
+        TITLE: 'Kieli',
+        NAVBAR_TITLE: 'Valitse kieli',
+        COMING_SOON: 'Tulossa pian',
+      },
+      THEME: {
+        LABEL: 'Teema',
+        NAVBAR_TITLE: 'Valitse teema',
+        TITLE_1: 'Valitse sovelluksen',
+        TITLE_2: 'ulkoasu',
+        SUBTITLE: 'Oletko enemmän yökyöpeli?',
+      },
+      SECURITY: {
+        LABEL: 'Turvallisuus',
+        NAVBAR_TITLE: 'Turvallisuus',
+        SWITCH_LABEL: 'Avaa {type:string}',
+        BIOMETRIC_TYPE: {
+          ANDROID: {
+            FACE_ID: 'kasvontunnistus',
+            TOUCH_ID: 'sormenjälki',
+          },
+          IOS: {
+            FACE_ID: 'Face ID',
+            TOUCH_ID: 'Touch ID',
+          },
+          GENERIC: 'biometria',
+        },
+        ENABLE: {
+          DIALOG_TITLE: 'Ota käyttöön {type:string}',
+          DIALOG_CONTENT: 'Anna salasanasi ottaaksesi {type:string} käyttöön.',
+        },
+        DISABLE: {
+          DIALOG_TITLE: 'Poista käytöstä {type:string}',
+          DIALOG_CONTENT: 'Anna salasanasi poistaaksesi {type:string} käytöstä.',
+        },
+      },
+      PASSWORD: {
+        TITLE: 'Salasana',
+      },
+      ONBOARDING_JOURNEY: {
+        TITLE: 'Aloituspolku',
+        BUTTON_TEXT: 'Aloita alusta',
+      },
+      HINTS_AND_TIPS: {
+        TITLE: 'Vinkit',
+        BUTTON_TEXT: 'Palauta',
+      },
+      DEVELOPER_MODE: {
+        TITLE: 'Kehittäjätila',
+      },
+    },
+    BACKUP_RECOVERY: {
+      TITLE: 'Varmuuskopiointi ja palautus',
+    },
+    LOG_OUT: {
+      TITLE: 'Kirjaudu ulos',
+    },
+    THEME: {
+      SYSTEM: 'Järjestelmä',
+      LIGHT: 'Vaalea',
+      DARK: 'Tumma',
+    },
+    PASSWORD: {
+      POLICY: {
+        TITLE: 'Salasanassa oltava',
+        UPPERCASE_LETTER: 'iso kirjain',
+        LOWERCASE_LETTER: 'pieni kirjain',
+        NUMBER: 'numero',
+        CHARACTERS: 'merkkiä',
+      },
+    },
+    RESET_APP: {
+      TITLE: 'Nollaa sovellus',
+      DESCRIPTION: 'Haluatko varmasti nollata sovelluksen ja poistaa kaikki tiedot?',
+      CONFIRM: 'Kyllä, poista kaikki',
+      CANCEL: 'Ei, säilytä profiilini',
+    },
+    ACCOUNT: 'Tili',
+    SUPPORT: {
+      TITLE: 'Tuki',
+      ABOUT: {
+        TITLE: 'Tietoja UniMesta',
+        NAVBAR_TITLE: 'Tietoja UniMesta',
+        SPECIFICATIONS: 'Tekniset tiedot',
+        VERSION: 'Versio',
+        LICENSE: 'Lisenssi',
+        BUILT_WITH: 'Rakennettu Tauri-tekniikalla',
+      },
+      FEEDBACK: {
+        TITLE: 'Lähetä palautetta',
+      },
+    },
+  },
+  LOCK_SCREEN: {
+    PASSWORD_INPUT_PLACEHOLDER: 'Anna salasanasi',
+    BUTTON_TEXT: 'Avaa lompakko',
+    FORGOT_PASSWORD: 'Unohtuiko salasana?',
+  },
+  ME: {
+    BOTTOM_NAVIGATION_TITLE: 'Minä',
+    GREETINGS: {
+      GREETING_0: 'Hei',
+      GREETING_1: 'Mitä kuuluu',
+      GREETING_2: 'Kuinka voit',
+      GREETING_3: 'Tervetuloa takaisin',
+      GREETING_4: 'Moi',
+    },
+    CREDENTIAL_TABS: {
+      ALL: 'Kaikki',
+      DATA: 'Data',
+      BADGES: 'Merkit',
+    },
+    EMPTY_CREDENTIALS: {
+      TITLE: 'Täällä on aika hiljaista',
+      SUBTITLE: 'Hanki joitakin tietojasi varmennettuna aloittaaksesi matkasi.',
+    },
+    FAVORITES: 'Suosikkini',
+  },
+  ACTIVITY: {
+    BOTTOM_NAVIGATION_TITLE: 'Aktiviteetti',
+    NAVBAR_TITLE: 'Yhdistetyt',
+    TABS: {
+      CONNECTIONS: 'Yhteydet',
+      HISTORY: 'Historia',
+    },
+  },
+  SCAN: {
+    BOTTOM_NAVIGATION_TITLE: 'Skannaa',
+    TITLE_1: 'Skannaa',
+    TITLE_2: 'QR-koodi',
+    SUBTITLE: 'Tuo QR-koodi näkyviin aloittaaksesi vuorovaikutuksen.',
+    PERMISSION_DENIED: 'Ei oikeutta kameran käyttöön',
+    OPEN_SETTINGS: 'Avaa asetukset',
+    CREDENTIAL_OFFER: {
+      NAVBAR_TITLE: 'Valtuustarjous',
+      DESCRIPTION: 'tarjoaa sinulle seuraavat valtuudet',
+      ACCEPT: 'Hyväksy valtuudet',
+    },
+    CONNECTION_REQUEST: {
+      NAVBAR_TITLE: 'Yhteyspyyntö',
+      TITLE: 'Uusi yhteys',
+      DESCRIPTION: 'Hyväksy vain yhteydet jotka tunnistat ja joihin luotat',
+      CONNECTED_PREVIOUSLY: 'Yhdistetty aiemmin',
+      ACCEPT: 'Hyväksy yhteys',
+    },
+    SHARE_CREDENTIALS: {
+      NAVBAR_TITLE: 'Jaa dataa',
+      DESCRIPTION: 'pyytää seuraavia valtuuksia',
+      REQUESTED: 'Pyydetty',
+      APPROVE: 'Hyväksy pyyntö',
+    },
+  },
+  CONNECTION: {
+    TABS: {
+      SUMMARY: 'Yhteenveto',
+      DATA: 'Data',
+      ACTIVITY: 'Aktiviteetti',
+    },
+    SUMMARY: {
+      EMPTY: 'Ei vielä yhteyksiä.',
+      TITLE: 'Yhdistetty kohteeseen',
+      FIRST_CONNECTED: 'Ensimmäinen yhdistys',
+      LAST_CONNECTED: 'Viimeksi yhdistetty',
+    },
+    DATA: {
+      EMPTY: 'Ei vielä dataa.',
+    },
+  },
+  HISTORY: {
+    EMPTY: 'Ei vielä aktiviteettia.',
+    DATA_RECEIVED: 'Vastaanotettu data kohteesta',
+    DATA_SHARED: 'Jaettu data kohteeseen',
+    CONNECTION_ADDED: 'Yhdistetty kohteeseen',
+  },
+  SEARCH: {
+    INPUT_PLACEHOLDER: 'Hae jotain',
+    NO_QUERY: {
+      TITLE: 'Mitä haetaan?',
+      DESCRIPTION: 'Hae mitä tahansa valtuuksiasi ja merkkejä täältä.',
+    },
+    NO_RESULTS: {
+      TITLE: 'Ei tuloksia',
+      DESCRIPTION: 'Kokeile hakea jotain muuta.',
+    },
+    RECENT_SEARCHES: 'Viimeisimmät haut',
+  },
+  CREDENTIAL: {
+    NAVBAR_TITLE: 'Valtuuden tiedot',
+    DETAILS: {
+      VALID: 'Voimassa',
+      ISSUED_BY: 'Myöntäjä',
+      DESCRIPTION: 'Kuvaus',
+      OPEN_BADGES: {
+        ALIGNMENT: 'Tasaus',
+        CRITERIA: 'Kriteerit',
+      },
+    },
+    ACTIONS: {
+      EDIT: {
+        CONFIRM_BUTTON: 'Päivitä näyttönimi',
+      },
+      DELETE: {
+        BUTTON_LABEL: 'Poista valtuus',
+        TITLE: 'Poista valtuus',
+        DESCRIPTION:
+          'Haluatko varmasti poistaa tämän valtuuden lompakostasi? Toimintoa ei voi perua.',
+        CONFIRM_BUTTON: 'Poista',
+      },
+    },
+  },
+  ADD_CREDENTIALS: {
+    BUTTON: 'Lisää',
+    NAVBAR_TITLE: 'Lisää dataa',
+    EMAIL: {
+      TITLE: 'Sähköposti',
+      DESCRIPTION: 'Varmenna henkilökohtainen tai työsähköpostisi',
+      INFO: {
+        NAVBAR_TITLE: 'Varmennettu sähköposti',
+        TITLE: 'Varmennettu sähköposti',
+        DESCRIPTION: 'Ennen kuin aloitat',
+        ITEM_0: {
+          TITLE: 'Miksi varmentaa sähköposti UniMessa?',
+          DESCRIPTION:
+            'Varmennus osoittaa että osoite on todella sinun, mahdollistaen salasanattoman käytön ja henkilöllisyyden todentamisen.',
+        },
+        ITEM_1: {
+          TITLE: 'Miten se toimii?',
+          DESCRIPTION:
+            'Kun aloitat, UniMe lähettää osoitteesi palvelimelle. Saat kertakäyttökoodin sähköpostiisi. Syötä koodi UniMeen osoittaaksesi pääsyn.',
+        },
+        ITEM_2: {
+          TITLE: 'Onko tietoni turvassa?',
+          DESCRIPTION:
+            'Kyllä. Yhteydet ovat vahvasti salattuja ja tietosi säilytetään turvallisesti. Emme jaa tietoja ilman suostumustasi.',
+        },
+      },
+      ADD: {
+        NAVBAR_TITLE: 'Hanki varmennettu sähköposti',
+        LABEL: 'Millä nimellä haluat kutsua tätä osoitetta?',
+        LABEL_DISCLAIMER: 'Näkyy vain sinulle',
+        LABEL_PLACEHOLDER: 'Henkilökohtainen sähköposti',
+        VALUE_LABEL: 'Sähköposti',
+        VALUE_PLACEHOLDER: 'etunimi.sukunimi@esimerkki.com',
+        BUTTON_SEND: 'Lähetä varmennussähköposti',
+        BUTTON_SEND_AGAIN: 'Lähetä uudelleen',
+        CHECK_EMAIL: 'Tarkista postilaatikko ja syötä koodi alle.',
+      },
+    },
+  },
+  SORT: {
+    TITLE: 'Lajittelu',
+    PREFERENCES: {
+      LIST_VIEW: 'Listanäkymä',
+      GRID_VIEW: 'Ruudukkonäkymä',
+      ALPHABETICAL: 'Aakkosjärjestys',
+      DATE_ISSUED: 'Myöntämispäivä',
+      DATE_ADDED: 'Lisäyspäivä',
+    },
+    ORDER: {
+      A_Z: 'A–Ö',
+      Z_A: 'Ö–A',
+      NEWEST: 'Uusimmat ensin',
+      OLDEST: 'Vanhimmat ensin',
+    },
+  },
+  DOMAIN_LINKAGE: {
+    TITLE: 'Varmennettu sivusto',
+    SUCCESS: 'UniMe varmisti identiteetin turvallista kirjautumista varten.',
+    FAILURE: 'UniMe ei voinut varmentaa identiteetin ja domainin yhteyttä.',
+    UNKNOWN: 'UniMe ei löytänyt näyttöä domainin identiteetistä.',
+    CAUTION: 'Toimi varoen!',
+  },
+  ERROR: {
+    TITLE: 'Hups!',
+    DEFAULT_MESSAGE: 'Jotain meni pieleen. Yritä uudelleen.',
+  },
+  CANCEL: 'Peruuta',
+  CLOSE: 'Sulje',
+  DISCARD: 'Hylkää',
+  CONTINUE: 'Jatka',
+  SKIP: 'Ohita',
+  ACCEPT: 'Hyväksy',
+  REJECT: 'Hylkää',
+  GETTING_STARTED: {
+    SKIP_TITLE: 'Ohita aloitusopas',
+    SKIP_TEXT: 'Haluatko varmasti ohittaa aloitusoppaan?',
+  },
+} satisfies BaseTranslation;
+
+export default fi_FI;

--- a/unime/src/i18n/i18n-types.ts
+++ b/unime/src/i18n/i18n-types.ts
@@ -11,7 +11,9 @@ export type Locales =
 	| 'en-GB'
 	| 'en-US'
 	| 'es-ES'
+	| 'fi-FI'
 	| 'nl-NL'
+	| 'sv-FI'
 
 export type Translation = RootTranslation
 

--- a/unime/src/i18n/i18n-util.async.ts
+++ b/unime/src/i18n/i18n-util.async.ts
@@ -11,7 +11,9 @@ const localeTranslationLoaders = {
 	'en-GB': () => import('./en-GB'),
 	'en-US': () => import('./en-US'),
 	'es-ES': () => import('./es-ES'),
+	'fi-FI': () => import('./fi-FI'),
 	'nl-NL': () => import('./nl-NL'),
+	'sv-FI': () => import('./sv-FI'),
 }
 
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>): Translations =>

--- a/unime/src/i18n/i18n-util.sync.ts
+++ b/unime/src/i18n/i18n-util.sync.ts
@@ -10,7 +10,9 @@ import en from './en'
 import en_GB from './en-GB'
 import en_US from './en-US'
 import es_ES from './es-ES'
+import fi_FI from './fi-FI'
 import nl_NL from './nl-NL'
+import sv_FI from './sv-FI'
 
 const localeTranslations = {
 	'de-DE': de_DE,
@@ -18,7 +20,9 @@ const localeTranslations = {
 	'en-GB': en_GB,
 	'en-US': en_US,
 	'es-ES': es_ES,
+	'fi-FI': fi_FI,
 	'nl-NL': nl_NL,
+	'sv-FI': sv_FI,
 }
 
 export const loadLocale = (locale: Locales): void => {

--- a/unime/src/i18n/i18n-util.ts
+++ b/unime/src/i18n/i18n-util.ts
@@ -16,7 +16,9 @@ export const locales: Locales[] = [
 	'en-GB',
 	'en-US',
 	'es-ES',
-	'nl-NL'
+	'fi-FI',
+	'nl-NL',
+	'sv-FI'
 ]
 
 export const isLocale = (locale: string): locale is Locales => locales.includes(locale as Locales)

--- a/unime/src/i18n/sv-FI/index.ts
+++ b/unime/src/i18n/sv-FI/index.ts
@@ -1,0 +1,473 @@
+import type { BaseTranslation } from '../i18n-types';
+
+const sv_FI = {
+  ONBOARDING: {
+    WELCOME: {
+      GREETING: 'Välkommen',
+      WHAT_IS_UNIME_1: 'UniMe kopplar ihop din digitala värld säkert.',
+      WHAT_IS_UNIME_2: 'Skapa en helt ny identitetsprofil för att komma igång.',
+      CREATE_NEW_PROFILE: 'Skapa ny profil',
+      SELECT_LANGUAGE: 'Välj språk',
+    },
+    PLEDGE: {
+      NAVBAR_TITLE: 'UniMe-löfte',
+      TITLE_1: 'Inget fuffens',
+      TITLE_2: 'här',
+      SUBTITLE: 'Här är vårt löfte till dig.',
+      ITEM_1: {
+        TITLE: 'Vi delar inte dina data',
+        DESCRIPTION:
+          'Dina data tillhör dig och bara du bestämmer vem du delar dem med. Punkt. Dina data rör inte våra system om du inte väljer ett molnlagringsalternativ.',
+      },
+      ITEM_2: {
+        TITLE: 'Vi lägger inte in spårare',
+        DESCRIPTION:
+          'Vi spårar inte dina handlingar i bakgrunden. Punkt. Inte för test eller något annat. Vi samlar inte heller in anonym enhets- eller användningsstatistik.',
+      },
+      ITEM_3: {
+        TITLE: 'Du äger din information',
+        DESCRIPTION: 'Det är dags att du åter blir ägare till din personliga information.',
+      },
+    },
+    TERMS: {
+      NAVBAR_TITLE: 'Villkor',
+      TITLE_1: 'Här är den mindre',
+      TITLE_2: 'roliga delen',
+      SUBTITLE: 'Vi rekommenderar ändå att du läser detta noggrant.',
+      T_AND_C: {
+        TITLE: 'Villkor',
+        DESCRIPTION: 'Jag har läst och godkänner villkoren.',
+        DIALOG_TITLE: 'Villkor för Impierce Technologies B.V.',
+        LAST_UPDATED: 'Senast uppdaterad: 31 oktober 2024',
+        TL_DR:
+          'Som med alla appar måste vi informera dig om juridiska saker. Vi försöker hålla det tydligt och kort, men viss formalia krävs.',
+        // Note: this translation had not been verified by a legal expert.
+        FULL: `Välkommen till Impierce Technologies B.V. ("vi", "oss" eller "vår"). Dessa allmänna villkor ("Villkor") reglerar din åtkomst till UniMe - Identity Wallet-applikationen ("Tjänsten"). Genom att öppna eller använda Tjänsten godkänner du att vara bunden av dessa Villkor. Om du inte godkänner någon del av Villkoren ska du inte använda Tjänsten.
+
+Godkännande av villkor
+Genom att ladda ned, öppna eller använda Tjänsten bekräftar du att du har läst, förstått och godkänner dessa Villkor samt vår integritetspolicy. Om du använder Tjänsten för en organisations räkning intygar du att du har behörighet att binda organisationen till dessa Villkor.
+
+Användarens ansvar
+Datasäkerhet: Du ansvarar för att upprätthålla sekretess och säkerhet för dina enheter och eventuella autentiseringsuppgifter som används för åtkomst till Tjänsten. Impierce Technologies B.V. ansvarar inte för förlust eller kompromettering av dina data om du inte skyddar din enhet.
+Efterlevnad av lag: Du åtar dig att använda Tjänsten i enlighet med all tillämplig lagstiftning och reglering.
+Korrekt information: Du ansvarar för att all information som du lagrar eller delar via Tjänsten är korrekt och uppdaterad.
+
+Dataägande och integritet
+Ingen datainsamling: Vi samlar inte in, lagrar eller behandlar personuppgifter genom UniMe-applikationen. All identitetsdata finns endast på din enhet eller i det lagringsalternativ du väljer.
+Användarkontrollerad delning: Delning initieras och styrs endast av dig och sker direkt mellan dig och den utsedda parten. Vi har ingen åtkomst till eller insyn i din identitet eller dina aktiviteter.
+Tredje parts insamling: Observera att tredjepartsplattformar som Apple App Store eller Google Play Store självständigt kan samla in uppgifter om appens prestanda, användning och enhetsinformation.
+
+Immateriella rättigheter
+Ägande och licenser: Samtliga immateriella rättigheter i UniMe och relaterat material tillhör Impierce Technologies B.V. eller dess licensgivare. UniMe tillhandahålls dock som öppen källkod under Apache 2.0-licensen vilket gör det möjligt att använda, modifiera och distribuera programvaran enligt licensvillkoren.
+Licens: Genom att ladda ned eller använda UniMe godkänner du villkoren i Apache 2.0-licensen som beviljar en global, royaltyfri licens att använda, reproducera och distribuera programvaran med korrekt attribuering.
+Se hela Apache 2.0-licensen för mer information.
+
+Förbjudna aktiviteter
+Du åtar dig att inte utföra:
+Obehörig åtkomst: Försök att få obehörig åtkomst till Tjänsten eller dess system.
+Störning: Störa eller hindra Tjänstens säkerhet eller prestanda.
+Missbruk: Använda Tjänsten för olagliga, skadliga, bedrägliga, intrångsgörande eller andra illvilliga ändamål.
+
+Tredje parts tjänster
+Tjänsten kan innehålla länkar eller integrationer till tredjepartstjänster. Vi kontrollerar inte dessa och ansvarar inte för deras innehåll eller policyer. Användning sker på egen risk och styrs av deras villkor.
+
+Ansvarsfriskrivningar
+"I befintligt skick": Tjänsten tillhandahålls i befintligt skick och i mån av tillgänglighet utan några uttryckliga eller underförstådda garantier.
+Ingen garanti: Vi garanterar inte att Tjänsten är oavbruten, felfri, säker eller fri från virus eller andra skadliga komponenter.
+
+Ansvarsbegränsning
+I den omfattning lagen tillåter ansvarar Impierce Technologies B.V. inte för indirekta, tillfälliga, särskilda, följd- eller straffskador, inklusive men inte begränsat till förlust av vinst, data, användning, goodwill eller andra immateriella förluster som härrör från:
+din åtkomst till eller användning av, eller oförmåga att använda Tjänsten;
+tredje parts beteende eller innehåll i Tjänsten;
+innehåll som erhålls via Tjänsten.
+
+Ersättning
+Du åtar dig att hålla Impierce Technologies B.V., dess dotterbolag samt deras respektive direktörer, tjänstemän, anställda och ombud skadeslösa, försvara och ersätta dem för alla krav, ansvar, skador, förluster och kostnader som uppstår ur eller på något sätt är kopplade till:
+din åtkomst till eller användning av Tjänsten;
+ditt brott mot dessa Villkor;
+ditt intrång i någon annans rättigheter.
+
+Ändringar av villkoren
+Vi kan uppdatera eller ändra dessa Villkor då och då. Datumet "Senast uppdaterad" överst anger när senaste ändringar gjordes. Vi meddelar väsentliga ändringar genom att publicera de nya Villkoren på vår webbplats eller i Tjänsten. Fortsatt användning efter ändringar innebär att du accepterar de uppdaterade villkoren.
+
+Tillämplig lag och jurisdiktion
+Dessa Villkor styrs av och tolkas enligt Nederländernas lag. Eventuella tvister som uppstår ur eller i samband med dessa Villkor är föremål för nederländska domstolars exklusiva jurisdiktion.
+
+Ogiltighet (Separabilitet)
+Om någon bestämmelse i dessa Villkor bedöms vara ogiltig eller inte verkställbar påverkar det inte övriga bestämmelsers giltighet.
+
+Fullständigt avtal
+Dessa Villkor tillsammans med vår integritetspolicy utgör hela avtalet mellan dig och Impierce Technologies B.V. avseende din användning av Tjänsten.
+
+Kontaktuppgifter
+Frågor, kommentarer eller funderingar kring dessa Villkor:
+Impierce Technologies B.V.
+Karekietweide 6, 3993 CD, Houten, Nederländerna
+E-post: contact@impierce.com
+
+Språk
+Villkoren kan tillhandahållas i översättning. Vid konflikt har den engelskspråkiga versionen företräde.
+
+Genom att använda Tjänsten bekräftar du att du har läst, förstått och accepterar dessa Villkor. Impierce Technologies B.V. förblir engagerat i att erbjuda säkra och integritetsfokuserade lösningar med respekt för dina rättigheter och friheter.`,
+      },
+      OWNERSHIP: {
+        TITLE: 'Dataägande',
+        DESCRIPTION: 'Jag förstår att jag själv ansvarar för mina data.',
+      },
+    },
+    CUSTOMIZE: {
+      NAVBAR_TITLE: 'Anpassning',
+      NAME: {
+        TITLE_1: 'Nu kör vi! Välj ett',
+        TITLE_2: 'profilnamn',
+        SUBTITLE: 'Din profilinformation lämnar aldrig din enhet.',
+        INPUT_PLACEHOLDER: 'Ange ett profilnamn',
+      },
+      PICTURE: {
+        TITLE_1: 'Ställ in en',
+        TITLE_2: 'profilbild',
+        SUBTITLE: 'Gör den personlig.',
+      },
+    },
+    PASSWORD: {
+      NAVBAR_TITLE: 'Lösenord',
+      TITLE_1: 'Ställ in ditt nya',
+      TITLE_2: 'lösenord',
+      SUBTITLE: 'Välj ett starkt lösenord för att kryptera dina data.',
+      INPUT_PLACEHOLDER: 'Ange ett lösenord',
+      CONFIRM: {
+        NAVBAR_TITLE: 'Bekräfta lösenord',
+        TITLE_1: 'Bekräfta ditt nya',
+        TITLE_2: 'lösenord',
+        SUBTITLE: 'Säkerställ att du skrev rätt.',
+        INPUT_PLACEHOLDER: 'Skriv lösenordet igen',
+        MATCH: 'Lösenorden stämmer',
+        NO_MATCH: 'Lösenorden stämmer inte',
+      },
+      BIOMETRICS: {
+        TITLE: 'Aktivera {type:string}',
+        DESCRIPTION: 'Vill du ställa in {type:string} för att låsa upp appen?',
+        CONFIRM: 'Ja, använd {type:string}',
+        DECIDE_LATER: 'Bestäm senare',
+      },
+      COMPLETED: {
+        NAVBAR_TITLE: 'Lösenord satt',
+        TITLE_1: 'Din UniMe-profil är nu',
+        TITLE_2: 'skyddad',
+        MESSAGE_1: 'Säker & trygg.',
+        MESSAGE_2: 'Snyggt jobbat',
+      },
+    },
+  },
+  SETTINGS: {
+    NAVBAR_TITLE: 'Inställningar',
+    PROFILE: {
+      TITLE: 'Min profil',
+      PROFILE_NAME: {
+        TITLE: 'Profilnamn',
+        NAVBAR_TITLE: 'Ändra profilnamn',
+        INPUT_PLACEHOLDER: 'Ange ett profilnamn',
+        CONFIRM: 'Uppdatera',
+      },
+      DISPLAY_PICTURE: {
+        EDIT: 'Redigera',
+        CHANGE: 'Välj en profilbild',
+        REMOVE: 'Ta bort',
+      },
+      DELETE_PROFILE: {
+        TITLE: 'Ta bort profil',
+      },
+    },
+    APP: {
+      TITLE: 'Appinställningar',
+      NAVBAR_TITLE: 'Appinställningar',
+      LANGUAGE: {
+        TITLE: 'Språk',
+        NAVBAR_TITLE: 'Välj språk',
+        COMING_SOON: 'Kommer snart',
+      },
+      THEME: {
+        LABEL: 'Tema',
+        NAVBAR_TITLE: 'Välj tema',
+        TITLE_1: 'Välj appens',
+        TITLE_2: 'utseende',
+        SUBTITLE: 'Är du mer av en nattuggla?',
+      },
+      SECURITY: {
+        LABEL: 'Säkerhet',
+        NAVBAR_TITLE: 'Säkerhet',
+        SWITCH_LABEL: 'Lås upp med {type:string}',
+        BIOMETRIC_TYPE: {
+          ANDROID: {
+            FACE_ID: 'ansiktsigenkänning',
+            TOUCH_ID: 'fingeravtryck',
+          },
+          IOS: {
+            FACE_ID: 'Face ID',
+            TOUCH_ID: 'Touch ID',
+          },
+          GENERIC: 'biometri',
+        },
+        ENABLE: {
+          DIALOG_TITLE: 'Aktivera {type:string}',
+          DIALOG_CONTENT: 'Ange ditt lösenord för att aktivera {type:string}.',
+        },
+        DISABLE: {
+          DIALOG_TITLE: 'Inaktivera {type:string}',
+          DIALOG_CONTENT: 'Ange ditt lösenord för att inaktivera {type:string}.',
+        },
+      },
+      PASSWORD: {
+        TITLE: 'Lösenord',
+      },
+      ONBOARDING_JOURNEY: {
+        TITLE: 'Onboardingresa',
+        BUTTON_TEXT: 'Starta om',
+      },
+      HINTS_AND_TIPS: {
+        TITLE: 'Tips',
+        BUTTON_TEXT: 'Återställ',
+      },
+      DEVELOPER_MODE: {
+        TITLE: 'Utvecklarläge',
+      },
+    },
+    BACKUP_RECOVERY: {
+      TITLE: 'Säkerhetskopiering och återställning',
+    },
+    LOG_OUT: {
+      TITLE: 'Logga ut',
+    },
+    THEME: {
+      SYSTEM: 'System',
+      LIGHT: 'Ljust',
+      DARK: 'Mörkt',
+    },
+    PASSWORD: {
+      POLICY: {
+        TITLE: 'Ditt lösenord måste innehålla',
+        UPPERCASE_LETTER: 'versal',
+        LOWERCASE_LETTER: 'gemen',
+        NUMBER: 'siffra',
+        CHARACTERS: 'tecken',
+      },
+    },
+    RESET_APP: {
+      TITLE: 'Återställ app',
+      DESCRIPTION: 'Är du säker på att du vill återställa appen och ta bort all data?',
+      CONFIRM: 'Ja, ta bort allt',
+      CANCEL: 'Nej, behåll min profil',
+    },
+    ACCOUNT: 'Konto',
+    SUPPORT: {
+      TITLE: 'Support',
+      ABOUT: {
+        TITLE: 'Om UniMe',
+        NAVBAR_TITLE: 'Om UniMe',
+        SPECIFICATIONS: 'Specifikationer',
+        VERSION: 'Version',
+        LICENSE: 'Licens',
+        BUILT_WITH: 'Byggd med Tauri',
+      },
+      FEEDBACK: {
+        TITLE: 'Skicka feedback',
+      },
+    },
+  },
+  LOCK_SCREEN: {
+    PASSWORD_INPUT_PLACEHOLDER: 'Ange ditt lösenord',
+    BUTTON_TEXT: 'Lås upp plånbok',
+    FORGOT_PASSWORD: 'Glömt lösenord?',
+  },
+  ME: {
+    BOTTOM_NAVIGATION_TITLE: 'Jag',
+    GREETINGS: {
+      GREETING_0: 'Hej',
+      GREETING_1: 'Hur är läget',
+      GREETING_2: 'Hur mår du',
+      GREETING_3: 'Välkommen tillbaka',
+      GREETING_4: 'Hallå',
+    },
+    CREDENTIAL_TABS: {
+      ALL: 'Alla',
+      DATA: 'Data',
+      BADGES: 'Brickor',
+    },
+    EMPTY_CREDENTIALS: {
+      TITLE: 'Lite tomt här',
+      SUBTITLE: 'Varför inte få viss data verifierad för att komma igång?',
+    },
+    FAVORITES: 'Mina favoriter',
+  },
+  ACTIVITY: {
+    BOTTOM_NAVIGATION_TITLE: 'Aktivitet',
+    NAVBAR_TITLE: 'Anslutna',
+    TABS: {
+      CONNECTIONS: 'Anslutningar',
+      HISTORY: 'Historik',
+    },
+  },
+  SCAN: {
+    BOTTOM_NAVIGATION_TITLE: 'Skanna',
+    TITLE_1: 'Skanna en',
+    TITLE_2: 'QR-kod',
+    SUBTITLE: 'För in en QR-kod i bild för att starta en interaktion.',
+    PERMISSION_DENIED: 'Ingen behörighet till kameran',
+    OPEN_SETTINGS: 'Öppna inställningar',
+    CREDENTIAL_OFFER: {
+      NAVBAR_TITLE: 'Legitimationserbjudande',
+      DESCRIPTION: 'erbjuder dig följande legitimationer',
+      ACCEPT: 'Acceptera legitimationer',
+    },
+    CONNECTION_REQUEST: {
+      NAVBAR_TITLE: 'Anslutningsförfrågan',
+      TITLE: 'Ny anslutning',
+      DESCRIPTION: 'Acceptera bara anslutningar du känner igen och litar på',
+      CONNECTED_PREVIOUSLY: 'Tidigare ansluten',
+      ACCEPT: 'Acceptera anslutning',
+    },
+    SHARE_CREDENTIALS: {
+      NAVBAR_TITLE: 'Dela data',
+      DESCRIPTION: 'begär följande legitimationer',
+      REQUESTED: 'Begärt',
+      APPROVE: 'Godkänn förfrågan',
+    },
+  },
+  CONNECTION: {
+    TABS: {
+      SUMMARY: 'Översikt',
+      DATA: 'Data',
+      ACTIVITY: 'Aktivitet',
+    },
+    SUMMARY: {
+      EMPTY: 'Inga anslutningar ännu.',
+      TITLE: 'Ansluten till',
+      FIRST_CONNECTED: 'Först ansluten',
+      LAST_CONNECTED: 'Senast ansluten',
+    },
+    DATA: {
+      EMPTY: 'Ingen data ännu.',
+    },
+  },
+  HISTORY: {
+    EMPTY: 'Ingen aktivitet ännu.',
+    DATA_RECEIVED: 'Mottog data från',
+    DATA_SHARED: 'Delade data med',
+    CONNECTION_ADDED: 'Ansluten till',
+  },
+  SEARCH: {
+    INPUT_PLACEHOLDER: 'Sök efter något',
+    NO_QUERY: {
+      TITLE: 'Vad ska vi söka efter?',
+      DESCRIPTION: 'Sök efter alla dina legitimationer och brickor här.',
+    },
+    NO_RESULTS: {
+      TITLE: 'Inga resultat',
+      DESCRIPTION: 'Försök söka efter något annat.',
+    },
+    RECENT_SEARCHES: 'Senaste sökningar',
+  },
+  CREDENTIAL: {
+    NAVBAR_TITLE: 'Legitimationsinformation',
+    DETAILS: {
+      VALID: 'Giltig',
+      ISSUED_BY: 'Utfärdad av',
+      DESCRIPTION: 'Beskrivning',
+      OPEN_BADGES: {
+        ALIGNMENT: 'Justering',
+        CRITERIA: 'Kriterier',
+      },
+    },
+    ACTIONS: {
+      EDIT: {
+        CONFIRM_BUTTON: 'Uppdatera visningsnamn',
+      },
+      DELETE: {
+        BUTTON_LABEL: 'Ta bort legitimation',
+        TITLE: 'Ta bort legitimation',
+        DESCRIPTION:
+          'Är du säker på att du vill ta bort denna legitimation från din plånbok? Detta kan inte ångras.',
+        CONFIRM_BUTTON: 'Ta bort',
+      },
+    },
+  },
+  ADD_CREDENTIALS: {
+    BUTTON: 'Lägg till',
+    NAVBAR_TITLE: 'Lägg till data',
+    EMAIL: {
+      TITLE: 'E-post',
+      DESCRIPTION: 'Verifiera din privata eller arbetsadress',
+      INFO: {
+        NAVBAR_TITLE: 'Verifierad e-post',
+        TITLE: 'Verifierad e-post',
+        DESCRIPTION: 'Innan du börjar',
+        ITEM_0: {
+          TITLE: 'Varför verifiera e-post i UniMe?',
+          DESCRIPTION:
+            'Verifiering visar att adressen verkligen är din och möjliggör säkra, lösenordsfria inloggningar.',
+        },
+        ITEM_1: {
+          TITLE: 'Hur fungerar det?',
+          DESCRIPTION:
+            'När du startar skickar UniMe adressen till vårt system. Du får en engångskod i inkorgen. Ange koden i UniMe för att bevisa åtkomst.',
+        },
+        ITEM_2: {
+          TITLE: 'Är min information säker?',
+          DESCRIPTION:
+            'Ja. All kommunikation är starkt krypterad och information lagras säkert. Vi delar inget utan ditt samtycke.',
+        },
+      },
+      ADD: {
+        NAVBAR_TITLE: 'Skaffa verifierad e-post',
+        LABEL: 'Vad vill du kalla denna adress?',
+        LABEL_DISCLAIMER: 'Syns bara för dig',
+        LABEL_PLACEHOLDER: 'Privat e-post',
+        VALUE_LABEL: 'E-post',
+        VALUE_PLACEHOLDER: 'fornamn.efternamn@example.com',
+        BUTTON_SEND: 'Skicka verifieringsmail',
+        BUTTON_SEND_AGAIN: 'Skicka igen',
+        CHECK_EMAIL: 'Kontrollera din inkorg och ange koden nedan.',
+      },
+    },
+  },
+  SORT: {
+    TITLE: 'Sortering',
+    PREFERENCES: {
+      LIST_VIEW: 'Listvy',
+      GRID_VIEW: 'Rutnätsvy',
+      ALPHABETICAL: 'Alfabetisk',
+      DATE_ISSUED: 'Utfärdandedatum',
+      DATE_ADDED: 'Tillagt datum',
+    },
+    ORDER: {
+      A_Z: 'A till Ö',
+      Z_A: 'Ö till A',
+      NEWEST: 'Nyast först',
+      OLDEST: 'Äldst först',
+    },
+  },
+  DOMAIN_LINKAGE: {
+    TITLE: 'Verifierad webbplats',
+    SUCCESS: 'UniMe verifierade identiteten för säker inloggning.',
+    FAILURE: 'UniMe kunde inte verifiera kopplingen mellan identitet och domän.',
+    UNKNOWN: 'UniMe hittade inget bevis på domänens identitet.',
+    CAUTION: 'Var försiktig!',
+  },
+  ERROR: {
+    TITLE: 'Hoppsan!',
+    DEFAULT_MESSAGE: 'Något gick fel. Försök igen.',
+  },
+  CANCEL: 'Avbryt',
+  CLOSE: 'Stäng',
+  DISCARD: 'Kasta',
+  CONTINUE: 'Fortsätt',
+  SKIP: 'Hoppa över',
+  ACCEPT: 'Acceptera',
+  REJECT: 'Avvisa',
+  GETTING_STARTED: {
+    SKIP_TITLE: 'Hoppa över guiden',
+    SKIP_TEXT: 'Är du säker på att du vill hoppa över guiden?',
+  },
+} satisfies BaseTranslation;
+
+export default sv_FI;


### PR DESCRIPTION
# Description of change
Added i18n files for Finnish (fi-FI) and Swedish (sv-FI).

I believe that sv-SE (Swedish spoken in Sweden) should be the same as sv-FI (Swedish spoken in Finland), but I'm not sure if there are minor differences.

## How the change has been tested
I ran `npm run check` and `npm run test` after implementing the changes.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
