### PR TITLE
feat: support deep linking for `openid://` and `openid-credential-offer://`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13407,7 +13407,8 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.2"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v2#1a0b7916501fd493dfe62bf227a8604eb8d05938"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d430110d4ee102a9b673d3c03ff48098c80fe8ca71ba1ff52d8a5919538a1a6"
 dependencies = [
  "dunce",
  "plist",
@@ -13523,7 +13524,8 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-single-instance"
 version = "2.3.3"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v2#1a0b7916501fd493dfe62bf227a8604eb8d05938"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236043404a4d1502ed7cce11a8ec88ea1e85597eec9887b4701bb10b66b13b6e"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +666,53 @@ dependencies = [
  "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite 2.6.1",
+ "rustix 1.0.8",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.8",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1101,7 +1160,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -1924,7 +1983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1991,6 +2050,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_format"
@@ -3017,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "dlopen2"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1297103d2bbaea85724fcee6294c2d50b1081f9ad47d0f6f6f61eda65315a6"
+checksum = "b54f373ccf864bf587a89e880fb7610f8d73f3045f13580948ccbcaff26febff"
 dependencies = [
  "dlopen2_derive",
  "libc",
@@ -3036,6 +3115,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.105",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -3295,6 +3383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
 name = "enum-compat-util"
 version = "0.1.0"
 source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
@@ -3309,6 +3403,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.105",
@@ -4967,7 +5082,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7701,7 +7816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8577,6 +8692,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8993,6 +9121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-javascript-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9052cb1bb50a4c161d934befcf879526fb87ae9a68858f241e693ca46225cf5a"
+dependencies = [
+ "objc2 0.6.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9029,6 +9167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-security"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f8e0ef3ab66b08c42644dcb34dba6ec0a574bbd8adbb8bdbdc7a2779731a44"
+dependencies = [
+ "bitflags 2.9.1",
+ "objc2 0.6.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-ui-kit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9052,6 +9201,8 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
+ "objc2-javascript-core",
+ "objc2-security",
 ]
 
 [[package]]
@@ -9274,6 +9425,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -11075,6 +11246,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11922,9 +12104,9 @@ dependencies = [
 
 [[package]]
 name = "serialize-to-javascript"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9823f2d3b6a81d98228151fdeaf848206a7855a7a042bbf9bf870449a66cafb"
+checksum = "04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -11933,13 +12115,13 @@ dependencies = [
 
 [[package]]
 name = "serialize-to-javascript-impl"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74064874e9f6a15f04c1f3cb627902d0e6b410abbf36668afa873c61889f1763"
+checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12697,7 +12879,7 @@ dependencies = [
  "libc",
  "libsodium-sys-stable",
  "log",
- "nix",
+ "nix 0.24.3",
  "rand 0.8.5",
  "serde",
  "thiserror 1.0.69",
@@ -12979,11 +13161,12 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.0"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
+checksum = "4daa814018fecdfb977b59a094df4bd43b42e8e21f88fddfc05807e6f46efaaf"
 dependencies = [
  "bitflags 2.9.1",
+ "block2 0.6.1",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
@@ -13061,12 +13244,13 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352a4bc7bf6c25f5624227e3641adf475a6535707451b09bb83271df8b7a6ac7"
+checksum = "a54629607ea3084a8b455c1ebe888cbdfc4de02fa5edb2e40db0dc97091007e3"
 dependencies = [
  "anyhow",
  "bytes",
+ "cookie",
  "dirs 6.0.0",
  "dunce",
  "embed_plist",
@@ -13085,6 +13269,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation 0.3.1",
  "objc2-ui-kit",
+ "objc2-web-kit",
  "percent-encoding",
  "plist",
  "raw-window-handle",
@@ -13112,9 +13297,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "182d688496c06bf08ea896459bf483eb29cdff35c1c4c115fb14053514303064"
+checksum = "67945dbaf8920dbe3a1e56721a419a0c3d085254ab24cff5b9ad55e2b0016e0b"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -13128,15 +13313,15 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.8.23",
+ "toml 0.9.5",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54a99a6cd8e01abcfa61508177e6096a4fe2681efecee9214e962f2f073ae4a"
+checksum = "1ab3a62cf2e6253936a8b267c2e95839674e7439f104fa96ad0025e149d54d8a"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -13161,9 +13346,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7945b14dc45e23532f2ded6e120170bbdd4af5ceaa45784a6b33d250fbce3f9e"
+checksum = "4368ea8094e7045217edb690f493b55b30caf9f3e61f79b4c24b6db91f07995e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -13175,9 +13360,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd5c1e56990c70a906ef67a9851bbdba9136d26075ee9a2b19c8b46986b3e02"
+checksum = "9946a3cede302eac0c6eb6c6070ac47b1768e326092d32efbb91f21ed58d978f"
 dependencies = [
  "anyhow",
  "glob",
@@ -13186,7 +13371,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "toml 0.8.23",
+ "toml 0.9.5",
  "walkdir",
 ]
 
@@ -13217,6 +13402,26 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.14",
+]
+
+[[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.2"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v2#1a0b7916501fd493dfe62bf227a8604eb8d05938"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.14",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -13278,9 +13483,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-os"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bccb4c6de4299beec5a9b070878a01bce9e2c945aa7a75bcea38bcba4c675d"
+checksum = "77a1c77ebf6f20417ab2a74e8c310820ba52151406d0c80fbcea7df232e3f6ba"
 dependencies = [
  "gethostname",
  "log",
@@ -13316,10 +13521,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.3.3"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v2#1a0b7916501fd493dfe62bf227a8604eb8d05938"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.14",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1cc885be806ea15ff7b0eb47098a7b16323d9228876afda329e34e2d6c4676"
+checksum = "d4cfc9ad45b487d3fded5a4731a567872a4812e9552e3964161b08edabf93846"
 dependencies = [
  "cookie",
  "dpi",
@@ -13328,20 +13548,23 @@ dependencies = [
  "jni",
  "objc2 0.6.1",
  "objc2-ui-kit",
+ "objc2-web-kit",
  "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
  "thiserror 2.0.14",
  "url",
+ "webkit2gtk",
+ "webview2-com",
  "windows 0.61.3",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe653a2fbbef19fe898efc774bc52c8742576342a33d3d028c189b57eb1d2439"
+checksum = "5bb0f10f831f75832ac74d14d98f701868f9a8adccef2c249b466cf70b607db9"
 dependencies = [
  "gtk",
  "http 1.3.1",
@@ -13366,9 +13589,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330c15cabfe1d9f213478c9e8ec2b0c76dab26bb6f314b8ad1c8a568c1d186e"
+checksum = "41a3852fdf9a4f8fbeaa63dc3e9a85284dd6ef7200751f0bd66ceee30c93f212"
 dependencies = [
  "anyhow",
  "brotli",
@@ -13395,7 +13618,7 @@ dependencies = [
  "serde_with 3.14.0",
  "swift-rs",
  "thiserror 2.0.14",
- "toml 0.8.23",
+ "toml 0.9.5",
  "url",
  "urlpattern",
  "uuid",
@@ -14037,6 +14260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14203,6 +14432,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14328,11 +14568,13 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-barcode-scanner",
  "tauri-plugin-biometric",
+ "tauri-plugin-deep-link",
  "tauri-plugin-fs",
  "tauri-plugin-keystore",
  "tauri-plugin-log",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tempfile",
  "tokio",
  "typetag",
@@ -14855,7 +15097,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -15018,6 +15260,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings",
 ]
 
 [[package]]
@@ -15484,14 +15737,15 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wry"
-version = "0.52.1"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a714d9ba7075aae04a6e50229d6109e3d584774b99a6a8c60de1698ca111b9"
+checksum = "5698e50a589268aec06d2219f48b143222f7b5ad9aa690118b8dce0a8dcac574"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.1",
  "cookie",
  "crossbeam-channel",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",
@@ -15695,6 +15949,66 @@ dependencies = [
  "quote",
  "syn 2.0.105",
  "synstructure 0.13.2",
+]
+
+[[package]]
+name = "zbus"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-lite 2.6.1",
+ "hex",
+ "nix 0.30.1",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.59.0",
+ "winnow 0.7.12",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.12",
+ "zvariant",
 ]
 
 [[package]]
@@ -15906,4 +16220,45 @@ checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.12",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "static_assertions",
+ "syn 2.0.105",
+ "winnow 0.7.12",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ resolver = "2"
 members = ["identity-wallet", "unime/src-tauri"]
 
 [workspace.dependencies]
-tauri = { version = "2.2.5", features = ["protocol-asset", "rustls-tls"] }
-tauri-build = "2.0.5"
+tauri = { version = "2.8.2", features = ["protocol-asset", "rustls-tls"] }
+tauri-build = "2.4.0"
 
 did_manager = { git = "https://git@github.com/impierce/did-manager", tag = "v1.0.0-beta.5" }
 jsonwebtoken = "9.3"

--- a/identity-wallet/bindings/AppState.ts
+++ b/identity-wallet/bindings/AppState.ts
@@ -9,4 +9,4 @@ import type { SearchResults } from "./search/SearchResults";
 import type { TrustLists } from "./trust_list/TrustLists";
 import type { VerifiedData } from "./verified_data/VerifiedData";
 
-export interface AppState { version: number, dids: Record<string, string>, connections: Connections, credentials: Array<DisplayCredential>, trust_lists: TrustLists, search_results: SearchResults, profile_settings: ProfileSettings, current_user_prompt: CurrentUserPrompt | null, user_journey: any | null, debug_messages: Array<string>, history: Array<HistoryEvent>, verified_data: VerifiedData, show_dev_mode_setting: boolean, dev_mode: DevMode, }
+export interface AppState { version: number, dids: Record<string, string>, connections: Connections, credentials: Array<DisplayCredential>, trust_lists: TrustLists, search_results: SearchResults, profile_settings: ProfileSettings, current_user_prompt: CurrentUserPrompt | null, user_journey: any | null, debug_messages: Array<string>, history: Array<HistoryEvent>, verified_data: VerifiedData, show_dev_mode_setting: boolean, is_unlocked: boolean, dev_mode: DevMode, }

--- a/identity-wallet/src/state/common/reducers/get_state.rs
+++ b/identity-wallet/src/state/common/reducers/get_state.rs
@@ -13,6 +13,7 @@ pub async fn get_state(_state: AppState, _action: Action) -> Result<AppState, Ap
 
     if state.profile_settings.profile.is_some() {
         state.current_user_prompt = Some(CurrentUserPrompt::PasswordRequired);
+        state.is_unlocked = false;
     } else {
         // TODO: bug: if state is present, but empty, user will never be redirected to neither welcome or profile page
         state.current_user_prompt = Some(CurrentUserPrompt::Redirect {

--- a/identity-wallet/src/state/common/reducers/unlock_storage.rs
+++ b/identity-wallet/src/state/common/reducers/unlock_storage.rs
@@ -59,6 +59,7 @@ pub async fn unlock_storage(state: AppState, action: Action) -> Result<AppState,
             current_user_prompt: Some(CurrentUserPrompt::Redirect {
                 target: "me".to_string(),
             }),
+            is_unlocked: true,
             ..state
         });
     }

--- a/identity-wallet/src/state/core_utils/helpers.rs
+++ b/identity-wallet/src/state/core_utils/helpers.rs
@@ -52,13 +52,15 @@ pub async fn get_issuer_document(resolver: &Resolver, credential_jwt: &Jwt) -> O
 }
 
 /// Validate a jwt_vc_json, checks the JWT and the Issuer DID.
-pub async fn validate_jwt_vc_json(credential_jwt: Jwt) -> Result<DecodedJwtCredential<Value>, AppError> {
+pub async fn validate_jwt_vc_json(
+    resolver: &Resolver,
+    credential_jwt: Jwt,
+) -> Result<DecodedJwtCredential<Value>, AppError> {
     // `SkipUnsupported` allows for custom credential types, such as the StatusList2021Entry (https://www.w3.org/TR/2023/WD-vc-status-list-20230427/#statuslist2021entry)
     let validator = JwtCredentialValidator::with_signature_verifier(Verifier);
     let options = JwtCredentialValidationOptions::new().status_check(StatusCheck::SkipUnsupported);
 
-    let resolver = Resolver::new().await;
-    let issuer_document = get_issuer_document(&resolver, &credential_jwt)
+    let issuer_document = get_issuer_document(resolver, &credential_jwt)
         .await
         .ok_or(AppError::Error("Failed to resolve issuer DID".to_string()))?;
 

--- a/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
@@ -34,6 +34,7 @@ pub async fn send_credential_request(state: AppState, action: Action) -> Result<
         listen::<CredentialOffersSelected>(action).map(|payload| payload.credential_configuration_ids)
     {
         let state_guard = state.core_utils.managers.lock().await;
+        let resolver = state.core_utils.resolver().await;
         let stronghold_manager = state_guard
             .stronghold_manager
             .as_ref()
@@ -167,7 +168,7 @@ pub async fn send_credential_request(state: AppState, action: Action) -> Result<
                             .ok_or(AppError::Error("Invalid JWT string.".to_string()))?
                             .to_string(),
                     );
-                    validate_jwt_vc_json(credential_jwt).await?;
+                    validate_jwt_vc_json(&resolver, credential_jwt).await?;
 
                     vec![(
                         credential_configuration_id,
@@ -199,7 +200,7 @@ pub async fn send_credential_request(state: AppState, action: Action) -> Result<
                                     .ok_or(AppError::Error("Invalid JWT string.".to_string()))?
                                     .to_string(),
                             );
-                            validate_jwt_vc_json(credential_jwt).await?;
+                            validate_jwt_vc_json(&resolver, credential_jwt).await?;
 
                             result.push((
                                 credential_configuration_id,

--- a/identity-wallet/src/state/mod.rs
+++ b/identity-wallet/src/state/mod.rs
@@ -112,6 +112,7 @@ pub struct AppState {
     #[ts(skip)]
     pub extensions: std::collections::HashMap<String, Box<dyn FeatTrait>>,
     pub show_dev_mode_setting: bool,
+    pub is_unlocked: bool,
     pub dev_mode: DevMode,
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@tauri-apps/plugin-biometric':
         specifier: ^2.2.0
         version: 2.2.0
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.1
+        version: 2.4.2
       '@tauri-apps/plugin-fs':
         specifier: ^2.2.0
         version: 2.2.0
@@ -835,6 +838,9 @@ packages:
   '@tauri-apps/api@2.3.0':
     resolution: {integrity: sha512-33Z+0lX2wgZbx1SPFfqvzI6su63hCBkbzv+5NexeYjIx7WA9htdOKoRR7Dh3dJyltqS5/J8vQFyybiRoaL0hlA==}
 
+  '@tauri-apps/api@2.8.0':
+    resolution: {integrity: sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==}
+
   '@tauri-apps/cli-darwin-arm64@2.3.1':
     resolution: {integrity: sha512-TOhSdsXYt+f+asRU+Dl+Wufglj/7+CX9h8RO4hl5k7D6lR4L8yTtdhpS7btaclOMmjYC4piNfJE70GoxhOoYWw==}
     engines: {node: '>= 10'}
@@ -905,6 +911,9 @@ packages:
 
   '@tauri-apps/plugin-biometric@2.2.0':
     resolution: {integrity: sha512-bxetRUGNGIuH/zMMlZ1VuYG7B0pWA/GkNDyMKmajCC3T3AIgL+siyeorDw+lAcp9KDNnTZ8vSOlxiAcwdbWN4Q==}
+
+  '@tauri-apps/plugin-deep-link@2.4.2':
+    resolution: {integrity: sha512-og3F/wNrTKh1vdgnGr5fG/vJYHvok114PIZy2zjx753GKqHAaZpngaNc6aP3pKnSqvUp3sjgBbPn/DeJ+CXwrA==}
 
   '@tauri-apps/plugin-fs@2.2.0':
     resolution: {integrity: sha512-+08mApuONKI8/sCNEZ6AR8vf5vI9DXD4YfrQ9NQmhRxYKMLVhRW164vdW5BSLmMpuevftpQ2FVoL9EFkfG9Z+g==}
@@ -3709,6 +3718,8 @@ snapshots:
 
   '@tauri-apps/api@2.3.0': {}
 
+  '@tauri-apps/api@2.8.0': {}
+
   '@tauri-apps/cli-darwin-arm64@2.3.1':
     optional: true
 
@@ -3759,6 +3770,10 @@ snapshots:
   '@tauri-apps/plugin-biometric@2.2.0':
     dependencies:
       '@tauri-apps/api': 2.3.0
+
+  '@tauri-apps/plugin-deep-link@2.4.2':
+    dependencies:
+      '@tauri-apps/api': 2.8.0
 
   '@tauri-apps/plugin-fs@2.2.0':
     dependencies:

--- a/unime/UniMe.desktop
+++ b/unime/UniMe.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Categories=
 Comment=Identity Wallet for people to manage Decentralized Identities and Verifiable Credentials
 Exec=gnome-terminal -- /usr/bin/unime %U
 Icon=unime

--- a/unime/UniMe.desktop
+++ b/unime/UniMe.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Comment=Identity Wallet for people to manage Decentralized Identities and Verifiable Credentials
-Exec=gnome-terminal -- /usr/bin/unime %U
+Exec=/usr/bin/unime %U
 Icon=unime
 Name=UniMe
 Terminal=false

--- a/unime/UniMe.desktop
+++ b/unime/UniMe.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Categories=
+Comment=Identity Wallet for people to manage Decentralized Identities and Verifiable Credentials
+Exec=gnome-terminal -- /usr/bin/unime %U
+Icon=unime
+Name=UniMe
+Terminal=false
+Type=Application
+MimeType=x-scheme-handler/openid;x-scheme-handler/openid-credential-offer

--- a/unime/package.json
+++ b/unime/package.json
@@ -35,6 +35,7 @@
     "@tauri-apps/cli": "^2.2.7",
     "@tauri-apps/plugin-barcode-scanner": "^2.2.0",
     "@tauri-apps/plugin-biometric": "^2.2.0",
+    "@tauri-apps/plugin-deep-link": "^2.4.1",
     "@tauri-apps/plugin-fs": "^2.2.0",
     "@tauri-apps/plugin-log": "^2.2.1",
     "@tauri-apps/plugin-os": "^2.2.0",

--- a/unime/src-tauri/Cargo.toml
+++ b/unime/src-tauri/Cargo.toml
@@ -29,11 +29,16 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 tauri-plugin-barcode-scanner = { version = "2" }
+tauri-plugin-deep-link = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v2" }
 tauri-plugin-fs = { version = "2" }
 tauri-plugin-keystore = { version = "2.1.0-alpha.1" }
 tauri-plugin-log = { version = "2", features = ["colored"] }
 tauri-plugin-os = { version = "2" }
 tauri-plugin-shell = { version = "2" }
+[target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
+tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v2", features = [
+    "deep-link",
+] }
 
 [dev-dependencies]
 tauri = { workspace = true, features = ["test"] }

--- a/unime/src-tauri/Cargo.toml
+++ b/unime/src-tauri/Cargo.toml
@@ -29,16 +29,14 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 tauri-plugin-barcode-scanner = { version = "2" }
-tauri-plugin-deep-link = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v2" }
+tauri-plugin-deep-link = { version = "2" }
 tauri-plugin-fs = { version = "2" }
 tauri-plugin-keystore = { version = "2.1.0-alpha.1" }
 tauri-plugin-log = { version = "2", features = ["colored"] }
 tauri-plugin-os = { version = "2" }
 tauri-plugin-shell = { version = "2" }
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
-tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v2", features = [
-    "deep-link",
-] }
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 
 [dev-dependencies]
 tauri = { workspace = true, features = ["test"] }

--- a/unime/src-tauri/capabilities/main.json
+++ b/unime/src-tauri/capabilities/main.json
@@ -4,7 +4,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "deep-link:allow-get-current",
+    "deep-link:default",
     "fs:default",
     "log:default",
     "shell:allow-open",

--- a/unime/src-tauri/capabilities/main.json
+++ b/unime/src-tauri/capabilities/main.json
@@ -4,6 +4,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "deep-link:allow-get-current",
     "fs:default",
     "log:default",
     "shell:allow-open",

--- a/unime/src-tauri/gen-static/apple/ExportOptions.plist
+++ b/unime/src-tauri/gen-static/apple/ExportOptions.plist
@@ -2,14 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- Use "development" for local testing, use "release-testing" for TestFlight releases -->
+    <!-- Use "debugging" for local testing, use "release-testing" for TestFlight releases -->
 
 	<!-- <key>method</key>
-    <string>development</string>
+    <string>debugging</string>
     <key>provisioningProfiles</key>
 	<dict>
 		<key>com.impierce.identity-wallet</key>
-		<string>UniMe Beta - Development Profile</string>
+		<string>UniMe - Development Profile</string>
 	</dict> -->
 
     <key>method</key>
@@ -17,7 +17,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>com.impierce.identity-wallet</key>
-		<string>UniMe Beta - Distribution Profile</string>
+		<string>UniMe - Distribution Profile</string>
 	</dict>
 </dict>
 </plist>

--- a/unime/src-tauri/gen-static/apple/unime_iOS/Info.plist
+++ b/unime/src-tauri/gen-static/apple/unime_iOS/Info.plist
@@ -16,6 +16,29 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.6.12</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.impierce.identity-wallet</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>openid</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.impierce.identity-wallet</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>openid-credential-offer</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>0.6.12</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/unime/src-tauri/src/lib.rs
+++ b/unime/src-tauri/src/lib.rs
@@ -20,7 +20,7 @@ pub fn run() {
     #[cfg(desktop)]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|_app, argv, _cwd| {
-            info!("New instance opened via deep link: {argv:?}");
+            info!("New app instance opened via deep link: {argv:?}");
         }));
     }
 

--- a/unime/src-tauri/src/lib.rs
+++ b/unime/src-tauri/src/lib.rs
@@ -15,8 +15,18 @@ use jni::{
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|_app, argv, _cwd| {
+            info!("New instance opened via deep link: {argv:?}");
+        }));
+    }
+
+    builder
         .invoke_handler(tauri::generate_handler![tauri_command::handle_action])
+        .plugin(tauri_plugin_deep_link::init())
         .setup(move |app| {
             info!("setting up tauri app");
             initialize_storage(app.handle()).ok();

--- a/unime/src-tauri/src/lib.rs
+++ b/unime/src-tauri/src/lib.rs
@@ -26,7 +26,6 @@ pub fn run() {
 
     builder
         .invoke_handler(tauri::generate_handler![tauri_command::handle_action])
-        .plugin(tauri_plugin_deep_link::init())
         .setup(move |app| {
             info!("setting up tauri app");
             initialize_storage(app.handle()).ok();
@@ -57,6 +56,7 @@ pub fn run() {
                 )
                 .build(),
         )
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_shell::init())

--- a/unime/src-tauri/tauri.conf.json
+++ b/unime/src-tauri/tauri.conf.json
@@ -46,8 +46,24 @@
     "iOS": {
       "developmentTeam": "Impierce Technologies B.V."
     },
+    "linux": {
+      "deb": {
+        "desktopTemplate": "../UniMe.desktop"
+      }
+    },
     "resources": [
       "resources/*"
     ]
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        { "scheme": [ "openid" ] },
+        { "scheme": [ "openid-credential-offer" ] }
+      ],
+      "desktop": {
+        "schemes": ["openid", "openid-credential-offer"]
+      }
+    }
   }
 }

--- a/unime/src/lib/stores.ts
+++ b/unime/src/lib/stores.ts
@@ -44,6 +44,7 @@ const empty_state: AppState = {
     email_verification: null,
   },
   show_dev_mode_setting: false,
+  is_unlocked: false,
   dev_mode: 'Off',
 };
 

--- a/unime/src/routes/+layout.svelte
+++ b/unime/src/routes/+layout.svelte
@@ -78,13 +78,10 @@
       // Update locale based on the frontend state.
       setLocale($appState.profile_settings.locale);
 
-      // The app is considered ready when it is unlocked.
-      const appIsReady = $appState?.is_unlocked;
-      const pendingUrl = get(pendingDeepLinkUrl);
-
-      if (appIsReady && pendingUrl) {
-        // If the app is ready and there's a URL, process it now.
-        processDeepLink(pendingUrl);
+      // Process a deep link (only if the app is already unlocked).
+      const url = get(pendingDeepLinkUrl);
+      if ($appState?.is_unlocked && url) {
+        processDeepLink(url);
       }
 
       let redirectPath: string | undefined;
@@ -115,24 +112,20 @@
 
     dispatch({ type: '[App] Get state' });
 
-    // Listen for deep links.
-    // If the app is launched with a deep link, we store it for later processing.
+    // If the app is launched with a deep link, it is stored for later processing via the `state-changed` listener.
     const invocationUrls = await getCurrent();
     if (invocationUrls) {
-      info(`App launched with deep link, storing for later: ${invocationUrls}`);
+      info(`App launched with deep links: ${invocationUrls}`);
       pendingDeepLinkUrl.set(new URL(invocationUrls[0]));
     }
 
-    // For subsequent links, also just store them. The state-changed listener will handle processing.
+    // If a deep link is received with the app already open, try processing it immediately.
     unlistenDeepLink = await onOpenUrl((urls) => {
       info(`Received deep link while running, storing for processing: ${urls[0]}`);
       const invocationUrl = new URL(urls[0]);
       pendingDeepLinkUrl.set(invocationUrl);
 
-      // Also try to process it immediately in case the app is already ready.
-      const appIsReady = $appState?.is_unlocked;
-
-      if (appIsReady) {
+      if ($appState?.is_unlocked) {
         processDeepLink(invocationUrl);
       }
     });
@@ -140,7 +133,7 @@
 
   onDestroy(() => {
     // Destroy in reverse order.
-    if (unlistenDeepLink) unlistenDeepLink();
+    unlistenDeepLink();
     unlistenStateChanged();
     unlistenError();
     detachConsole();

--- a/unime/src/routes/+layout.svelte
+++ b/unime/src/routes/+layout.svelte
@@ -7,12 +7,13 @@
   import LL, { setLocale } from '$i18n/i18n-svelte';
   import { loadAllLocales } from '$i18n/i18n-util.sync';
   import type { SVGAttributes } from 'svelte/elements';
-  import { writable } from 'svelte/store';
+  import { get, writable } from 'svelte/store';
   import { fly } from 'svelte/transition';
 
   import type { AppState } from '@bindings/AppState';
   import type { ProfileSteps } from '@bindings/dev/ProfileSteps';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+  import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
   import { attachConsole, error, info } from '@tauri-apps/plugin-log';
 
   import { DeprecatedSwitch, Toast } from '$lib/components';
@@ -34,6 +35,31 @@
   let detachConsole: UnlistenFn;
   let unlistenError: UnlistenFn;
   let unlistenStateChanged: UnlistenFn;
+  let unlistenDeepLink: UnlistenFn;
+
+  const pendingDeepLinkUrl = writable<URL | undefined>();
+
+  async function processDeepLink(url: URL) {
+    info(`App is ready, processing pending deep link: ${url}`);
+
+    // Clear the URL from the store immediately to prevent it from being processed again.
+    pendingDeepLinkUrl.set(undefined);
+
+    switch (url.protocol) {
+      case 'openid-credential-offer:':
+      case 'openid:': {
+        await dispatch({
+          type: '[QR Code] Scanned',
+          payload: { form_urlencoded: url.toString() },
+        });
+        break;
+      }
+      default: {
+        error(`Received deep link with unhandled protocol: ${url.protocol}`);
+        break;
+      }
+    }
+  }
 
   onMount(async () => {
     detachConsole = await attachConsole();
@@ -51,6 +77,15 @@
 
       // Update locale based on the frontend state.
       setLocale($appState.profile_settings.locale);
+
+      // The app is considered ready when it is unlocked.
+      const appIsReady = $appState?.is_unlocked;
+      const pendingUrl = get(pendingDeepLinkUrl);
+
+      if (appIsReady && pendingUrl) {
+        // If the app is ready and there's a URL, process it now.
+        processDeepLink(pendingUrl);
+      }
 
       let redirectPath: string | undefined;
 
@@ -79,10 +114,33 @@
     });
 
     dispatch({ type: '[App] Get state' });
+
+    // Listen for deep links.
+    // If the app is launched with a deep link, we store it for later processing.
+    const invocationUrls = await getCurrent();
+    if (invocationUrls) {
+      info(`App launched with deep link, storing for later: ${invocationUrls}`);
+      pendingDeepLinkUrl.set(new URL(invocationUrls[0]));
+    }
+
+    // For subsequent links, also just store them. The state-changed listener will handle processing.
+    unlistenDeepLink = await onOpenUrl((urls) => {
+      info(`Received deep link while running, storing for processing: ${urls[0]}`);
+      const invocationUrl = new URL(urls[0]);
+      pendingDeepLinkUrl.set(invocationUrl);
+
+      // Also try to process it immediately in case the app is already ready.
+      const appIsReady = $appState?.is_unlocked;
+
+      if (appIsReady) {
+        processDeepLink(invocationUrl);
+      }
+    });
   });
 
   onDestroy(() => {
     // Destroy in reverse order.
+    if (unlistenDeepLink) unlistenDeepLink();
     unlistenStateChanged();
     unlistenError();
     detachConsole();


### PR DESCRIPTION
# Description of change
This pull request introduces deep linking functionality to the application, allowing it to be opened via custom URL schemes like `openid://` and `openid-credential-offer://`.

Key Features & Fixes
* Deep Link Integration:
  * The application now handles custom URL schemes, whether it's launched by the link or the link is received while the app is already running.
  * On desktop, this uses the single-instance plugin to ensure links are correctly forwarded to the existing application instance.
  * A `UniMe.desktop` file has been added to register the custom schemes on Linux (for testing/dev purposes).
* Race Condition Resolution:
  * A new `is_unlocked` flag has been added to the global `AppState`.
  * The frontend queues incoming deep links and only processes them once the `is_unlocked` flag is `true`, preventing errors that occurred when trying to process links before the wallet was unlocked.
* Performance Refactoring:
  * Fix: The `validate_jwt_vc_json` function has been refactored to accept the application's existing DID Resolver. This ensures that in Android the required `tls_config` is used. It also solves the performance cost of creating a new resolver instance on every credential validation.

## Links to any relevant issues
n/a

## How the change has been tested
Manually tested against ssi-agent `beta.11`

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
