### PR TITLE
ci: bump version strings to `0.10.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5591,7 +5591,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identity-wallet"
-version = "0.6.12"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14550,7 +14550,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unime"
-version = "0.6.12"
+version = "0.10.0"
 dependencies = [
  "did_manager",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ iota-execution = { git = "https://github.com/impierce/iota", package = "iota-exe
 
 [workspace.package]
 name = "unime"
-version = "0.6.12"
+version = "0.10.0"
 description = "Identity Wallet for people to manage Decentralized Identities and Verifiable Credentials"
 homepage = "https://www.impierce.com/"
 authors = ["Impierce Technologies"]

--- a/identity-wallet/Cargo.toml
+++ b/identity-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-wallet"
-version = "0.6.12"
+version = "0.10.0"
 edition = "2021"
 rust-version.workspace = true
 

--- a/unime/package.json
+++ b/unime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unime",
   "private": true,
-  "version": "0.6.12",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/unime/src-tauri/Cargo.toml
+++ b/unime/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unime"
-version = "0.6.12"
+version = "0.10.0"
 description = "Identity Wallet for people to manage Decentralized Identities and Verifiable Credentials"
 homepage = "https://www.impierce.com/"
 authors = ["Impierce Technologies"]

--- a/unime/src-tauri/gen-static/android/app/tauri.properties
+++ b/unime/src-tauri/gen-static/android/app/tauri.properties
@@ -1,1 +1,1 @@
-tauri.android.versionName=0.6.12
+tauri.android.versionName=0.10.0

--- a/unime/src-tauri/gen-static/apple/unime_iOS/Info.plist
+++ b/unime/src-tauri/gen-static/apple/unime_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.12</string>
+	<string>0.10.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.6.12</string>
+	<string>0.10.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/unime/src-tauri/tauri.conf.json
+++ b/unime/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "UniMe",
-  "version": "0.6.12",
+  "version": "0.10.0",
   "identifier": "com.impierce.identity-wallet",
   "app": {
     "security": {

--- a/unime/src/routes/(app)/me/settings/about/+page.svelte
+++ b/unime/src/routes/(app)/me/settings/about/+page.svelte
@@ -67,7 +67,7 @@
     {/if}
     <section class="mb-4 flex flex-col items-center">
       <h2 class="font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.VERSION()}</h2>
-      <div class="mb-3">0.6.12</div>
+      <div class="mb-3">0.10.0</div>
       <div class="flex items-center">
         <p>{$LL.SETTINGS.SUPPORT.ABOUT.BUILT_WITH()}</p>
         <HeartFillIcon class="pl-1" />


### PR DESCRIPTION
# Description of change

All UniMe-related version strings are bumped to the latest version available on the app stores.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
