### PR TITLE
build: bump `identity.rs` dependencies to `v1.6.0-beta.7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -2832,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "anyhow",
  "identity_iota",
@@ -2847,7 +2847,7 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "did-jwk",
  "identity_iota",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "did-method-key",
  "identity_iota",
@@ -2882,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "did_manager"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "consumer",
  "producer",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "did-web",
  "identity_iota",
@@ -5838,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -9251,7 +9251,7 @@ dependencies = [
 [[package]]
 name = "oid4vc"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
+source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
 dependencies = [
  "oid4vc-core",
  "oid4vc-manager",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "oid4vc-core"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
+source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9288,7 +9288,7 @@ dependencies = [
 [[package]]
 name = "oid4vc-manager"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
+source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "oid4vci"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
+source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "oid4vp"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
+source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "producer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -12237,7 +12237,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
+source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.6#e8f68b575a3ee354ac4b08663939917977974556"
 dependencies = [
  "identity_iota",
  "identity_storage",
@@ -12381,7 +12381,7 @@ dependencies = [
 [[package]]
 name = "siopv2"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
+source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,28 +743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,14 +905,15 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "async-trait",
- "axum-core 0.4.5",
+ "axum-core 0.5.2",
+ "axum-macros",
  "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -942,7 +921,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -992,13 +971,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -1008,6 +986,17 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1160,7 +1149,7 @@ dependencies = [
  "bitflags 2.9.2",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1983,7 +1972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2014,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc#7e49c58b826b34c8e2b61842ef13c8de35a0aee8"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -2024,25 +2013,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "consensus-config"
-version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
-dependencies = [
- "fastcrypto",
- "iota-network-stack",
- "rand 0.8.5",
- "serde",
- "shared-crypto",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
+name = "console"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
- "cfg-if",
- "wasm-bindgen",
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2106,7 +2085,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "consumer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -2853,12 +2832,12 @@ dependencies = [
 [[package]]
 name = "did_iota"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "anyhow",
  "identity_iota",
  "identity_stronghold",
- "iota-sdk 0.12.0-rc",
+ "iota-sdk 1.6.1",
  "log",
  "rustls 0.23.31",
  "shared",
@@ -2868,12 +2847,12 @@ dependencies = [
 [[package]]
 name = "did_jwk"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "did-jwk",
  "identity_iota",
  "identity_stronghold",
- "iota-sdk 0.12.0-rc",
+ "iota-sdk 1.6.1",
  "log",
  "serde_json",
  "shared",
@@ -2885,12 +2864,12 @@ dependencies = [
 [[package]]
 name = "did_key"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "did-method-key",
  "identity_iota",
  "identity_stronghold",
- "iota-sdk 0.12.0-rc",
+ "iota-sdk 1.6.1",
  "jsonwebkey",
  "log",
  "serde_json",
@@ -2903,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "did_manager"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "consumer",
  "producer",
@@ -2941,12 +2920,12 @@ dependencies = [
 [[package]]
 name = "did_web"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "did-web",
  "identity_iota",
  "identity_stronghold",
- "iota-sdk 0.12.0-rc",
+ "iota-sdk 1.6.1",
  "log",
  "serde_json",
  "shared",
@@ -3367,6 +3346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,7 +3369,7 @@ checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "serde_yaml",
 ]
@@ -3550,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898#2f502fd8570fe4e9cff36eea5bbd6fef22002898"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3604,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898#2f502fd8570fe4e9cff36eea5bbd6fef22002898"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3613,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898#2f502fd8570fe4e9cff36eea5bbd6fef22002898"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -3632,7 +3617,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898#2f502fd8570fe4e9cff36eea5bbd6fef22002898"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -3649,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898#2f502fd8570fe4e9cff36eea5bbd6fef22002898"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4374,7 +4359,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "http 1.3.1",
  "js-sys",
  "pin-project",
@@ -4408,19 +4393,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -5057,7 +5029,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5579,9 +5551,9 @@ dependencies = [
  "dyn-clone",
  "futures",
  "icu",
- "identity_core 1.6.0-beta (git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.2)",
+ "identity_core 1.6.0-beta (git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.7)",
  "identity_credential",
- "identity_eddsa_verifier 1.6.0-beta (git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.2)",
+ "identity_eddsa_verifier 1.6.0-beta (git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.7)",
  "identity_iota",
  "identity_jose",
  "iota_stronghold",
@@ -5620,7 +5592,7 @@ dependencies = [
 [[package]]
 name = "identity_core"
 version = "1.6.0-beta"
-source = "git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.2#0ecce7b015ca5b7a731a7ff62dad101a1a4a3bfe"
+source = "git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.7#eb4c93abd7452bff8ccb919821a9949fbb838f5c"
 dependencies = [
  "deranged",
  "js-sys",
@@ -5637,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "identity_core"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "deranged",
  "js-sys",
@@ -5654,13 +5626,13 @@ dependencies = [
 [[package]]
 name = "identity_credential"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "anyhow",
  "async-trait",
  "flate2",
  "futures",
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_did",
  "identity_document",
  "identity_verification",
@@ -5670,7 +5642,7 @@ dependencies = [
  "once_cell",
  "roaring",
  "sd-jwt-payload 0.2.1",
- "sd-jwt-payload 0.3.0",
+ "sd-jwt-payload 0.4.0",
  "serde",
  "serde-aux",
  "serde_json",
@@ -5683,11 +5655,11 @@ dependencies = [
 [[package]]
 name = "identity_did"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "did_url_parser 0.3.0",
  "form_urlencoded",
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_jose",
  "serde",
  "strum 0.25.0",
@@ -5697,10 +5669,10 @@ dependencies = [
 [[package]]
 name = "identity_document"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "did_url_parser 0.2.0",
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_did",
  "identity_verification",
  "indexmap 2.10.0",
@@ -5712,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "identity_eddsa_verifier"
 version = "1.6.0-beta"
-source = "git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.2#0ecce7b015ca5b7a731a7ff62dad101a1a4a3bfe"
+source = "git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.7#eb4c93abd7452bff8ccb919821a9949fbb838f5c"
 dependencies = [
  "identity_jose",
  "iota-crypto",
@@ -5721,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "identity_eddsa_verifier"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "identity_jose",
  "iota-crypto",
@@ -5730,9 +5702,9 @@ dependencies = [
 [[package]]
 name = "identity_iota"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_credential",
  "identity_did",
  "identity_document",
@@ -5746,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "identity_iota_core"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5754,16 +5726,16 @@ dependencies = [
  "cfg-if",
  "fastcrypto",
  "futures",
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_credential",
  "identity_did",
  "identity_document",
- "identity_eddsa_verifier 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_eddsa_verifier 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_jose",
  "identity_verification",
- "iota-config 0.12.0-rc (git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc)",
+ "iota-config",
  "iota-crypto",
- "iota-sdk 0.12.0-rc",
+ "iota-sdk 1.6.1",
  "iota_interaction",
  "iota_interaction_rust",
  "iota_interaction_ts",
@@ -5784,18 +5756,17 @@ dependencies = [
  "strum 0.25.0",
  "thiserror 1.0.69",
  "tokio",
- "toml 0.8.23",
 ]
 
 [[package]]
 name = "identity_jose"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "anyhow",
  "bls12_381_plus 0.8.18",
  "fastcrypto",
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "iota-crypto",
  "iota_interaction",
  "json-proof-token",
@@ -5810,11 +5781,11 @@ dependencies = [
 [[package]]
 name = "identity_resolver"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "async-trait",
  "futures",
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_credential",
  "identity_did",
  "identity_document",
@@ -5827,14 +5798,14 @@ dependencies = [
 [[package]]
 name = "identity_storage"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
  "fastcrypto",
  "futures",
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_credential",
  "identity_did",
  "identity_document",
@@ -5851,7 +5822,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold"
 version = "1.6.0-beta"
-source = "git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.2#0ecce7b015ca5b7a731a7ff62dad101a1a4a3bfe"
+source = "git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.7#eb4c93abd7452bff8ccb919821a9949fbb838f5c"
 dependencies = [
  "async-trait",
  "identity_storage",
@@ -5867,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "identity_stronghold_ext"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "async-trait",
  "elliptic-curve 0.13.8",
@@ -5887,9 +5858,9 @@ dependencies = [
 [[package]]
 name = "identity_verification"
 version = "1.6.0-beta"
-source = "git+https://github.com/impierce/identity.rs?rev=82f41a29#82f41a2958bf1ff2314ecd78d0a9719e893679d9"
+source = "git+https://github.com/impierce/identity.rs?rev=251cbe5c#251cbe5c83dcb0d1214287645407cc70745865a6"
 dependencies = [
- "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=82f41a29)",
+ "identity_core 1.6.0-beta (git+https://github.com/impierce/identity.rs?rev=251cbe5c)",
  "identity_did",
  "identity_jose",
  "serde",
@@ -6040,6 +6011,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6061,9 +6044,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6075,10 +6069,10 @@ dependencies = [
  "iota-verifier-latest",
  "leb128",
  "move-binary-format",
- "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
  "move-core-types",
+ "move-trace-format",
  "move-vm-config",
  "move-vm-profiler",
  "move-vm-runtime",
@@ -6090,48 +6084,21 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "0.12.0-rc"
-source = "git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc#7e49c58b826b34c8e2b61842ef13c8de35a0aee8"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
  "clap 4.5.45",
- "consensus-config 0.1.0 (git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc)",
+ "consensus-config",
  "csv",
  "dirs 5.0.1",
  "fastcrypto",
- "iota-genesis-common 0.12.0-rc (git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc)",
- "iota-keys 0.12.0-rc (git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc)",
- "iota-protocol-config",
- "iota-types",
- "move-vm-config",
- "object_store",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "reqwest 0.12.23",
- "serde",
- "serde_yaml",
- "tracing",
-]
-
-[[package]]
-name = "iota-config"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
-dependencies = [
- "anemo",
- "anyhow",
- "bcs",
- "clap 4.5.45",
- "consensus-config 0.1.0 (git+https://github.com/impierce/iota?branch=temp/fix)",
- "csv",
- "dirs 5.0.1",
- "fastcrypto",
- "iota-genesis-common 0.12.0-rc (git+https://github.com/impierce/iota?branch=temp/fix)",
- "iota-keys 0.12.0-rc (git+https://github.com/impierce/iota?branch=temp/fix)",
- "iota-protocol-config",
+ "iota-genesis-common",
+ "iota-keys",
+ "iota-names",
+ "iota-rest-api",
  "iota-types",
  "move-vm-config",
  "object_store",
@@ -6181,8 +6148,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "serde_yaml",
 ]
@@ -6190,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -6198,16 +6165,17 @@ dependencies = [
  "iota-types",
  "iota-verifier-latest",
  "move-binary-format",
- "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
+ "move-trace-format",
  "move-vm-config",
  "move-vm-runtime",
+ "move-vm-types",
 ]
 
 [[package]]
 name = "iota-genesis-common"
-version = "0.12.0-rc"
-source = "git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc#7e49c58b826b34c8e2b61842ef13c8de35a0aee8"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6216,20 +6184,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-genesis-common"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+name = "iota-http"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
- "iota-execution",
- "iota-protocol-config",
- "iota-types",
- "prometheus",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
 ]
 
 [[package]]
 name = "iota-json"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6245,8 +6222,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6265,12 +6242,11 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
- "chrono",
  "colored",
  "enum_dispatch",
  "fastcrypto",
@@ -6278,6 +6254,7 @@ dependencies = [
  "iota-json",
  "iota-macros",
  "iota-metrics",
+ "iota-names",
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-types",
@@ -6286,6 +6263,8 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -6297,8 +6276,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "0.12.0-rc"
-source = "git+https://github.com/iotaledger/iota.git?tag=v0.12.0-rc#7e49c58b826b34c8e2b61842ef13c8de35a0aee8"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6308,35 +6287,18 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with 3.14.0",
  "shared-crypto",
  "signature 1.6.4",
  "slip10_ed25519",
  "tiny-bip39",
-]
-
-[[package]]
-name = "iota-keys"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
-dependencies = [
- "anyhow",
- "bip32",
- "fastcrypto",
- "iota-types",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "shared-crypto",
- "signature 1.6.4",
- "slip10_ed25519",
- "tiny-bip39",
+ "tracing",
 ]
 
 [[package]]
 name = "iota-macros"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6346,13 +6308,13 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anemo",
  "anemo-tower",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.4",
  "bytes",
  "dashmap",
  "futures",
@@ -6373,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "bcs",
  "better_any",
@@ -6394,9 +6356,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-names"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "iota-types",
+ "move-core-types",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "iota-network-stack"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anemo",
  "bcs",
@@ -6405,12 +6380,16 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body 1.0.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "iota-http",
  "multiaddr",
+ "once_cell",
  "pin-project-lite",
  "serde",
  "snap",
  "tokio",
- "tokio-stream",
+ "tokio-rustls 0.26.2",
  "tonic",
  "tonic-health",
  "tower 0.4.13",
@@ -6420,8 +6399,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -6431,8 +6410,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -6444,26 +6423,24 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "async-trait",
  "bcs",
- "eyre",
  "iota-types",
  "lru",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
- "serde",
  "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "iota-proc-macros"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -6473,22 +6450,23 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "clap 4.5.45",
  "iota-protocol-config-macros",
  "move-vm-config",
  "schemars 0.8.22",
  "serde",
+ "serde-env",
  "serde_with 3.14.0",
  "tracing",
 ]
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6496,9 +6474,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-rest-api"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+dependencies = [
+ "anyhow",
+ "axum 0.8.4",
+ "bcs",
+ "fastcrypto",
+ "iota-network-stack",
+ "iota-protocol-config",
+ "iota-rust-sdk",
+ "iota-types",
+ "itertools 0.13.0",
+ "mime",
+ "move-binary-format",
+ "openapiv3",
+ "prometheus",
+ "reqwest 0.12.23",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_with 3.14.0",
+ "serde_yaml",
+ "tap",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3e4a47351cdd774dd2895a2552a038fe2f4b6da5#3e4a47351cdd774dd2895a2552a038fe2f4b6da5"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=93580286f3714248398d17e4481daf608508856a#93580286f3714248398d17e4481daf608508856a"
 dependencies = [
  "base64ct",
  "bcs",
@@ -6513,41 +6520,6 @@ dependencies = [
  "serde_json",
  "serde_with 3.14.0",
  "winnow 0.6.26",
-]
-
-[[package]]
-name = "iota-sdk"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "bcs",
- "clap 4.5.45",
- "colored",
- "fastcrypto",
- "futures",
- "futures-core",
- "getset",
- "iota-config 0.12.0-rc (git+https://github.com/impierce/iota?branch=temp/fix)",
- "iota-json",
- "iota-json-rpc-api",
- "iota-json-rpc-types",
- "iota-keys 0.12.0-rc (git+https://github.com/impierce/iota?branch=temp/fix)",
- "iota-transaction-builder",
- "iota-types",
- "jsonrpsee",
- "move-core-types",
- "reqwest 0.12.23",
- "rustls 0.23.31",
- "serde",
- "serde_json",
- "serde_with 3.14.0",
- "shared-crypto",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -6595,9 +6567,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-sdk"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "bcs",
+ "colored",
+ "fastcrypto",
+ "futures",
+ "futures-core",
+ "getset",
+ "iota-config",
+ "iota-json",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-transaction-builder",
+ "iota-types",
+ "jsonrpsee",
+ "move-core-types",
+ "reqwest 0.12.23",
+ "rustls 0.23.31",
+ "serde",
+ "serde_json",
+ "serde_with 3.14.0",
+ "shared-crypto",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iota-transaction-builder"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6613,8 +6619,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6623,8 +6629,7 @@ dependencies = [
  "better_any",
  "bincode",
  "byteorder",
- "chrono",
- "consensus-config 0.1.0 (git+https://github.com/impierce/iota?branch=temp/fix)",
+ "consensus-config",
  "derive_more 1.0.0",
  "either",
  "enum_dispatch",
@@ -6637,7 +6642,6 @@ dependencies = [
  "indexmap 2.10.0",
  "iota-enum-compat-util",
  "iota-macros",
- "iota-metrics",
  "iota-network-stack",
  "iota-protocol-config",
  "iota-rust-sdk",
@@ -6646,18 +6650,13 @@ dependencies = [
  "lru",
  "move-binary-format",
  "move-bytecode-utils",
- "move-command-line-common",
  "move-core-types",
- "move-disassembler",
- "move-ir-types",
  "move-vm-profiler",
  "move-vm-test-utils",
- "move-vm-types",
  "nonempty 0.9.0",
  "num-bigint 0.4.6",
  "num-rational",
  "num-traits",
- "num_enum",
  "once_cell",
  "packable",
  "parking_lot 0.12.4",
@@ -6672,6 +6671,7 @@ dependencies = [
  "serde_with 3.14.0",
  "shared-crypto",
  "signature 1.6.4",
+ "starfish-config",
  "static_assertions",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -6685,9 +6685,8 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
- "iota-protocol-config",
  "iota-types",
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -6700,8 +6699,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.2.1"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.2.1#8b411b6b8dc3dc112dcffab7682114e8a7355a3b"
+version = "0.8.2"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6712,18 +6711,15 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "fastcrypto-zkp",
- "getrandom 0.2.16",
- "getrandom 0.3.3",
  "hex",
  "indexmap 2.10.0",
- "iota-sdk 0.12.0-rc",
+ "iota-sdk 1.6.1",
  "itertools 0.13.0",
  "jsonpath-rust",
  "jsonrpsee",
  "leb128",
  "move-core-types",
- "nonempty 0.11.0",
- "num-bigint 0.4.6",
+ "nonempty 0.1.5",
  "primitive-types 0.12.2",
  "rand 0.8.5",
  "ref-cast",
@@ -6735,7 +6731,6 @@ dependencies = [
  "serde_with 3.14.0",
  "shared-crypto",
  "strum 0.25.0",
- "tap",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6744,53 +6739,43 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.2.1"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.2.1#8b411b6b8dc3dc112dcffab7682114e8a7355a3b"
+version = "0.8.2"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "cfg-if",
- "fastcrypto",
- "iota-sdk 0.12.0-rc",
  "iota_interaction",
  "secret-storage",
  "serde",
- "serde_json",
- "strum 0.25.0",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.2.1"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.2.1#8b411b6b8dc3dc112dcffab7682114e8a7355a3b"
+version = "0.8.2"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "bls12_381_plus 0.8.18",
  "cfg-if",
- "console_error_panic_hook",
  "eyre",
  "fastcrypto",
  "futures",
  "getrandom 0.2.16",
  "getrandom 0.3.3",
- "instant",
+ "iota-sdk 1.1.5",
  "iota_interaction",
  "js-sys",
  "secret-storage",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "serde_repr",
+ "strum 0.25.0",
  "thiserror 1.0.69",
  "tokio",
- "tsify",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "zkryptium",
 ]
 
 [[package]]
@@ -6947,15 +6932,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -7807,7 +7783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -8042,6 +8018,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8148,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -8157,12 +8139,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -8176,12 +8158,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8197,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -8211,7 +8193,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -8226,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -8236,20 +8218,18 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
- "colored",
  "dirs-next",
  "hex",
+ "insta",
  "move-binary-format",
  "move-core-types",
- "num-bigint 0.4.6",
  "once_cell",
  "serde",
  "sha2 0.9.9",
- "similar",
  "vfs",
  "walkdir",
 ]
@@ -8257,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8265,6 +8245,7 @@ dependencies = [
  "codespan-reporting",
  "dunce",
  "hex",
+ "insta",
  "lsp-types",
  "move-binary-format",
  "move-borrow-graph",
@@ -8291,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8307,6 +8288,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
+ "serde_with 3.14.0",
  "thiserror 1.0.69",
  "uint",
 ]
@@ -8314,7 +8296,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8335,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8350,12 +8332,13 @@ dependencies = [
  "move-core-types",
  "move-coverage",
  "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -8373,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "hex",
@@ -8386,7 +8369,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -8399,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -8408,7 +8391,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -8423,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "once_cell",
  "phf 0.11.3",
@@ -8433,22 +8416,18 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
- "anyhow",
  "move-binary-format",
  "move-core-types",
- "move-proc-macros",
- "ref-cast",
  "serde",
  "serde_json",
- "variant_count",
 ]
 
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -8457,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -8467,7 +8446,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "better_any",
  "fail",
@@ -8487,7 +8466,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8501,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -8520,7 +8499,7 @@ checksum = "e7627d8bbeb17edbf1c3f74b21488e4af680040da89713b4217d0010e9cbd97e"
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.43#d3ae9de63b7ebfbeea8fa5f9d111b9570be703f2"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.46.1#20adc0b089bf9072268eea0f059fb8ea2461702f"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -8728,15 +8707,15 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.9.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6"
+checksum = "4f962080273ac958f790079cfc886b5b9d722969dbd7b03f473902bdfe5c69b1"
 
 [[package]]
 name = "nonempty"
-version = "0.11.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
+checksum = "995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6"
 
 [[package]]
 name = "nonzero_ext"
@@ -8944,7 +8923,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -9272,7 +9251,7 @@ dependencies = [
 [[package]]
 name = "oid4vc"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=8b024cb#8b024cb07ee39fd697d7acb275b61e41c114815b"
+source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
 dependencies = [
  "oid4vc-core",
  "oid4vc-manager",
@@ -9284,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "oid4vc-core"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=8b024cb#8b024cb07ee39fd697d7acb275b61e41c114815b"
+source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9309,7 +9288,7 @@ dependencies = [
 [[package]]
 name = "oid4vc-manager"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=8b024cb#8b024cb07ee39fd697d7acb275b61e41c114815b"
+source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9321,7 +9300,6 @@ dependencies = [
  "did_url",
  "futures",
  "getset",
- "identity_core 1.6.0-beta (git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.2)",
  "identity_credential",
  "jsonwebtoken",
  "lazy_static",
@@ -9343,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "oid4vci"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=8b024cb#8b024cb07ee39fd697d7acb275b61e41c114815b"
+source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9371,13 +9349,12 @@ dependencies = [
 [[package]]
 name = "oid4vp"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=8b024cb#8b024cb07ee39fd697d7acb275b61e41c114815b"
+source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
 dependencies = [
  "anyhow",
  "chrono",
  "futures",
  "getset",
- "identity_core 1.6.0-beta (git+https://github.com/iotaledger/identity?tag=v1.6.0-beta.2)",
  "identity_credential",
  "is_empty",
  "jsonwebtoken",
@@ -9425,6 +9402,17 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openapiv3"
+version = "2.0.0"
+source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
+dependencies = [
+ "indexmap 2.10.0",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10409,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "producer"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "did_iota",
  "did_jwk",
@@ -10430,13 +10418,15 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.2.1"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.2.1#8b411b6b8dc3dc112dcffab7682114e8a7355a3b"
+version = "0.8.2"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bcs",
  "cfg-if",
- "iota-sdk 0.12.0-rc",
+ "fastcrypto",
+ "iota-sdk 1.6.1",
  "iota_interaction",
  "iota_interaction_rust",
  "iota_interaction_ts",
@@ -10453,9 +10443,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -10463,17 +10453,16 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.4",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "anyhow",
  "prometheus",
- "protobuf",
 ]
 
 [[package]]
@@ -10493,7 +10482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -10501,11 +10490,22 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
- "bytes",
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -11621,7 +11621,7 @@ checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals 0.29.1",
+ "serde_derive_internals",
  "syn 2.0.106",
 ]
 
@@ -11672,8 +11672,8 @@ dependencies = [
 
 [[package]]
 name = "sd-jwt-payload"
-version = "0.3.0"
-source = "git+https://github.com/impierce/sd-jwt-payload?branch=fix/hasher-send-sync#9bccc38ec6119650334a55a06012f97a9fab81cb"
+version = "0.4.0"
+source = "git+https://github.com/impierce/sd-jwt-payload?branch=fix/hasher-send-sync#994ecbdda3637a06bb1dbcae1ad871d94f8ca9aa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11846,6 +11846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-env"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13536c0c431652192b75c7d5afa83dedae98f91d7e687ff30a009e9d15284fb"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
 name = "serde-name"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11912,17 +11922,6 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12238,7 +12237,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/impierce/did-manager?tag=v1.0.0-beta.5#518e3d38131c0fdba47b77ca624d0ae900f44b07"
+source = "git+https://github.com/impierce/did-manager?rev=21dc679#21dc6790008840ab4bfb1fbc0bfd409c4299afb0"
 dependencies = [
  "identity_iota",
  "identity_storage",
@@ -12254,8 +12253,8 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "bcs",
  "eyre",
@@ -12382,7 +12381,7 @@ dependencies = [
 [[package]]
 name = "siopv2"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=8b024cb#8b024cb07ee39fd697d7acb275b61e41c114815b"
+source = "git+https://github.com/impierce/openid4vc?rev=b7b8290#b7b829013a80ad52d48561efd9736d31b15a271d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12846,6 +12845,18 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "starfish-config"
+version = "0.1.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+dependencies = [
+ "fastcrypto",
+ "iota-network-stack",
+ "rand 0.8.5",
+ "serde",
+ "shared-crypto",
 ]
 
 [[package]]
@@ -13886,20 +13897,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.10",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13947,14 +13960,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.24.0",
+ "tungstenite 0.26.2",
 ]
 
 [[package]]
@@ -14084,13 +14097,12 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.4",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.12",
@@ -14106,19 +14118,19 @@ dependencies = [
  "socket2 0.5.10",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
 dependencies = [
- "async-stream",
  "prost",
  "tokio",
  "tokio-stream",
@@ -14154,11 +14166,15 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.10.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -14351,31 +14367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
-dependencies = [
- "gloo-utils 0.1.7",
- "serde",
- "serde_json",
- "tsify-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-macros"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals 0.28.0",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14397,26 +14388,25 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "utf-8",
 ]
 
 [[package]]
 name = "typed-store-error"
-version = "0.12.0-rc"
-source = "git+https://github.com/impierce/iota?branch=temp/fix#90084d420f010226775f389547d03fe3d2df81a9"
+version = "1.6.1"
+source = "git+https://github.com/iotaledger/iota?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -14608,7 +14598,7 @@ dependencies = [
  "did_manager",
  "dotenvy",
  "identity-wallet",
- "iota-sdk 0.12.0-rc",
+ "iota-sdk 1.6.1",
  "jni",
  "jsonwebtoken",
  "log",
@@ -15184,7 +15174,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,10 @@ members = ["identity-wallet", "unime/src-tauri"]
 tauri = { version = "2.8.2", features = ["protocol-asset", "rustls-tls"] }
 tauri-build = "2.4.0"
 
-# FIXME: update this once https://github.com/impierce/did-manager/pull/39 is merged.
-did_manager = { git = "https://github.com/impierce/did-manager", rev = "21dc679" }
+did_manager = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.6" }
 jsonwebtoken = "9.3"
 log = "^0.4"
-# FIXME: update this once https://github.com/impierce/openid4vc/pull/110 is merged.
-oid4vc = { git = "https://github.com/impierce/openid4vc", rev = "b7b8290" }
+oid4vc = { git = "https://github.com/impierce/openid4vc", rev = "99fc7be" }
 rand = "0.8"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rustls-platform-verifier = { version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,45 +6,33 @@ members = ["identity-wallet", "unime/src-tauri"]
 tauri = { version = "2.8.2", features = ["protocol-asset", "rustls-tls"] }
 tauri-build = "2.4.0"
 
-did_manager = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.5" }
+# FIXME: update this once https://github.com/impierce/did-manager/pull/39 is merged.
+did_manager = { git = "https://github.com/impierce/did-manager", rev = "21dc679" }
 jsonwebtoken = "9.3"
 log = "^0.4"
-oid4vc = { git = "https://github.com/impierce/openid4vc", rev = "8b024cb" }
+# FIXME: update this once https://github.com/impierce/openid4vc/pull/110 is merged.
+oid4vc = { git = "https://github.com/impierce/openid4vc", rev = "b7b8290" }
 rand = "0.8"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rustls-platform-verifier = { version = "0.6" }
 serde_json = "1.0"
 serial_test = "2.0"
 tempfile = "3.5.0"
-tokio = { version = "1.43.0", features = ["macros"] }
+tokio = { version = "1.46", features = ["macros"] }
 wiremock = "0.5"
-
-# TODO: Remove these patches once configurable TLS is available in `iota-sdk`.
-[patch.'https://github.com/iotaledger/iota']
-iota-sdk = { git = "https://github.com/impierce/iota", package = "iota-sdk", branch = "temp/fix" }
-move-core-types = { git = "https://github.com/impierce/iota", package = "move-core-types", branch = "temp/fix" }
-shared-crypto = { git = "https://github.com/impierce/iota", package = "shared-crypto", branch = "temp/fix" }
-iota-network-stack = { git = "https://github.com/impierce/iota", package = "iota-network-stack", branch = "temp/fix" }
-iota-types = { git = "https://github.com/impierce/iota", package = "iota-types", branch = "temp/fix" }
-iota-metrics = { git = "https://github.com/impierce/iota", package = "iota-metrics", branch = "temp/fix" }
-move-binary-format = { git = "https://github.com/impierce/iota", package = "move-binary-format", branch = "temp/fix" }
-iota-protocol-config = { git = "https://github.com/impierce/iota", package = "iota-protocol-config", branch = "temp/fix" }
-move-vm-config = { git = "https://github.com/impierce/iota", package = "move-vm-config", branch = "temp/fix" }
-iota-adapter-latest = { git = "https://github.com/impierce/iota", package = "iota-adapter-latest", branch = "temp/fix" }
-iota-execution = { git = "https://github.com/impierce/iota", package = "iota-execution", branch = "temp/fix" }
 
 # TODO: **WARNING**: These are temporary patches that allow us to create and validate both `dc+sd-jwt`s and
 # `vc+sd-jwt`s, but this is a very hacky workaround. We need to come up with a better long-term solution.
-# To see the actual changes, see: https://github.com/iotaledger/identity/compare/v1.6.0-beta.2...impierce:identity.rs:82f41a29
+# To see the actual changes, see: https://github.com/iotaledger/identity/compare/v1.6.0-beta.7...impierce:identity.rs:251cbe5c
 [patch.'https://github.com/iotaledger/identity']
-identity_credential = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
-identity_iota_core = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
-identity_storage = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
-identity_resolver = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
-identity_jose = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
-identity_document = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
-identity_verification = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
-identity_iota = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29" }
+identity_credential = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
+identity_iota_core = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
+identity_storage = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
+identity_resolver = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
+identity_jose = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
+identity_document = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
+identity_verification = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
+identity_iota = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c" }
 
 [workspace.package]
 name = "unime"

--- a/identity-wallet/Cargo.toml
+++ b/identity-wallet/Cargo.toml
@@ -20,17 +20,17 @@ dyn-clone = "1.0"
 futures = "0.3"
 icu = "1.4.0"
 # TODO: See ../Cargo.toml
-identity_credential = { git = "https://github.com/impierce/identity.rs", rev = "82f41a29", default-features = false, features = [
+identity_credential = { git = "https://github.com/impierce/identity.rs", rev = "251cbe5c", default-features = false, features = [
     "credential",
     "domain-linkage",
     "presentation",
     "validator",
     "sd-jwt-vc",
 ] }
-identity_core = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.2" }
-identity_eddsa_verifier = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.2" }
-identity_iota = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.2" }
-identity_jose = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.2" }
+identity_core = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.7" }
+identity_eddsa_verifier = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.7" }
+identity_iota = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.7" }
+identity_jose = { git = "https://github.com/iotaledger/identity", tag = "v1.6.0-beta.7" }
 iota_stronghold = { version = "2.1" }
 itertools = "0.10"
 jsonschema = "0.29"

--- a/unime/src-tauri/Cargo.toml
+++ b/unime/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ tauri.workspace = true
 
 dotenvy = { version = "0.15" }
 identity-wallet = { path = "../../identity-wallet" }
-iota-sdk = { git = "https://github.com/impierce/iota", package = "iota-sdk", branch = "temp/fix" }
+iota-sdk = { git = "https://github.com/iotaledger/iota", package = "iota-sdk", tag = "v1.6.1" }
 jni = "0.21"
 log.workspace = true
 rustls.workspace = true


### PR DESCRIPTION
# Description of change
* Update `identity.rs` related dependencies to `v1.6.0-beta.7`
* Remove patches that were previously required to support `rustls-platform-verifier` x `iota-sdk` on Android

## Links to any relevant issues
- https://github.com/iotaledger/iota/pull/7429

## How the change has been tested
* Existing tests still pass
* Manually validated that `rustls-platform-verifier` x `iota-sdk` on Android still works

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
