### PR TITLE
ci: add `rustfmt` and `clippy` components to `rust-toolchain`

### DIFF
--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Use Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Install dependencies
         working-directory: ./unime/src-tauri
@@ -94,7 +94,7 @@ jobs:
       - name: Use Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Install dependencies
         working-directory: ./identity-wallet

--- a/.github/workflows/format-lint-test.yaml
+++ b/.github/workflows/format-lint-test.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Use Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - name: Install dependencies
         working-directory: ./unime/src-tauri
@@ -91,6 +93,8 @@ jobs:
 
       - name: Use Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - name: Install dependencies
         working-directory: ./identity-wallet

--- a/identity-wallet/src/state/actions.rs
+++ b/identity-wallet/src/state/actions.rs
@@ -92,10 +92,11 @@ mod bindings {
         verified_data::actions::{RedeemCode, SendVerificationEmail, ServiceHealthCheck},
     };
 
+    #[allow(dead_code)]
     #[derive(Serialize, Deserialize, TS)]
     #[serde(tag = "type")]
     #[ts(export, export_to = "bindings/actions/Action.ts")]
-    pub enum Action {
+    enum Action {
         #[serde(rename = "[App] Get state")]
         GetState,
         #[serde(rename = "[Storage] Unlock")]


### PR DESCRIPTION
# Description of change
Fix for [failing workflow](https://github.com/impierce/identity-wallet/actions/runs/18012805350/job/51312033585) due to `rustfmt` (and `clippy`)) not being installed. By adding the `rustfmt` and `clippy` components (as described [here](https://github.com/marketplace/actions/rustup-toolchain-install#inputs)) the workflow runs as intended.

disclaimer: I'm not really sure about why this didn't cause any issues until now

## Links to any relevant issues
- https://github.com/impierce/identity-wallet/actions/runs/18012805350/job/51312033585

## How the change has been tested
Workflow corresponding to this PR succeeds

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
