### PR TITLE
build: bump `oid4vc`, fix credential configuration display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9251,7 +9251,7 @@ dependencies = [
 [[package]]
 name = "oid4vc"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
+source = "git+https://github.com/impierce/openid4vc?rev=4cbf854#4cbf854a51a2b3b1e7441804addae9785091990c"
 dependencies = [
  "oid4vc-core",
  "oid4vc-manager",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "oid4vc-core"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
+source = "git+https://github.com/impierce/openid4vc?rev=4cbf854#4cbf854a51a2b3b1e7441804addae9785091990c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9288,7 +9288,7 @@ dependencies = [
 [[package]]
 name = "oid4vc-manager"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
+source = "git+https://github.com/impierce/openid4vc?rev=4cbf854#4cbf854a51a2b3b1e7441804addae9785091990c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "oid4vci"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
+source = "git+https://github.com/impierce/openid4vc?rev=4cbf854#4cbf854a51a2b3b1e7441804addae9785091990c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "oid4vp"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
+source = "git+https://github.com/impierce/openid4vc?rev=4cbf854#4cbf854a51a2b3b1e7441804addae9785091990c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12381,7 +12381,7 @@ dependencies = [
 [[package]]
 name = "siopv2"
 version = "0.1.0"
-source = "git+https://github.com/impierce/openid4vc?rev=99fc7be#99fc7be1b86aec38c2d7fbe4ba64d17d9800c050"
+source = "git+https://github.com/impierce/openid4vc?rev=4cbf854#4cbf854a51a2b3b1e7441804addae9785091990c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ tauri-build = "2.4.0"
 did_manager = { git = "https://github.com/impierce/did-manager", tag = "v1.0.0-beta.6" }
 jsonwebtoken = "9.3"
 log = "^0.4"
-oid4vc = { git = "https://github.com/impierce/openid4vc", rev = "99fc7be" }
+oid4vc = { git = "https://github.com/impierce/openid4vc", rev = "4cbf854" }
 rand = "0.8"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rustls-platform-verifier = { version = "0.6" }

--- a/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
@@ -207,7 +207,7 @@ pub async fn send_credential_request(state: AppState, action: Action) -> Result<
                             authorization_server_metadata
                                 .pushed_authorization_request_endpoint
                                 .ok_or(AppError::Error(
-                                    "Authorization Server does not have a pushed authorirzation request endpoint"
+                                    "Authorization Server does not have a pushed authorization request endpoint"
                                         .to_string(),
                                 ))?
                                 .clone(),

--- a/unime/src/routes/prompt/credential-offer/+page.svelte
+++ b/unime/src/routes/prompt/credential-offer/+page.svelte
@@ -87,12 +87,11 @@
     <div
       class="mt-3 w-full rounded-[20px] border border-slate-200 bg-white p-[10px] dark:border-slate-600 dark:bg-dark"
     >
-      {#each Object.values(credential_configurations) as credential_configuration}
+      {#each Object.entries(credential_configurations) as [credential_configuration_id, credential_configuration]}
         <!-- TODO: bug: long list is not correctly displayed -->
         <ListItemCard
           id={hash(credential_configuration.display?.at(0)?.logo?.uri ?? '')}
-          title={credential_configuration.display?.at(0)?.name ??
-            credential_configuration.credential_definition.type.at(-1)}
+          title={credential_configuration.display?.at(0)?.name ?? credential_configuration_id}
           isTempAsset={true}
         >
           <div slot="right" class="mr-2">


### PR DESCRIPTION
# Description of change
* bump `oid4vc`
* fix typo
* this fallback: `credential_configuration.credential_definition.type.at(-1)` caused UniMe to freeze for credential configurations that do not have a display name **and are not Verifiable Credentials (e.g.: SD-JWTs)**. to fix this the fallback has been changed to `credential_configuration_id` since all Credential Configurations are guaranteed to have a `credential_configuration_id`.

## Links to any relevant issues
n/a

## How the change has been tested
Manually tested against:
* https://issuer.procivis.pensiondemo.findy.fi/?lang=en
* https://issuer.waltid.pensiondemo.findy.fi/?lang=en

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
