### PR TITLE
build: bump version strings to `0.12.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5495,7 +5495,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identity-wallet"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15622,7 +15622,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unime"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "did_manager",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sd-jwt = { git = "https://github.com/impierce/sd-jwt-payload", rev = "f28789a", 
 
 [workspace.package]
 name = "unime"
-version = "0.11.7"
+version = "0.12.0"
 description = "Identity Wallet for people to manage Decentralized Identities and Verifiable Credentials"
 homepage = "https://www.impierce.com/"
 authors = ["Impierce Technologies"]

--- a/identity-wallet/Cargo.toml
+++ b/identity-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-wallet"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2021"
 rust-version.workspace = true
 

--- a/identity-wallet/src/state/core_utils/mod.rs
+++ b/identity-wallet/src/state/core_utils/mod.rs
@@ -2,6 +2,8 @@ pub mod helpers;
 pub mod history_event;
 
 #[cfg(target_os = "android")]
+use log::info;
+#[cfg(target_os = "android")]
 use rustls::{client::danger::ServerCertVerifier, ClientConfig};
 #[cfg(target_os = "android")]
 use rustls::{

--- a/identity-wallet/src/subject.rs
+++ b/identity-wallet/src/subject.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "android")]
+use crate::state::core_utils::tls_config;
 use crate::stronghold::StrongholdManager;
 
 use async_trait::async_trait;
@@ -40,7 +42,7 @@ impl Subject {
         info!("Initializing resolver for Subject");
 
         #[cfg(target_os = "android")]
-        let resolver = Resolver::new_with_tls_config(tls_config().await.unwrap()).await;
+        let resolver = Resolver::new_with_options(Some(tls_config().await.unwrap()), None, None);
 
         info!("Resolver initialized");
 

--- a/unime/package.json
+++ b/unime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unime",
   "private": true,
-  "version": "0.11.7",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/unime/src-tauri/Cargo.toml
+++ b/unime/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unime"
-version = "0.11.7"
+version = "0.12.0"
 description = "Identity Wallet for people to manage Decentralized Identities and Verifiable Credentials"
 homepage = "https://www.impierce.com/"
 authors = ["Impierce Technologies"]

--- a/unime/src-tauri/gen-static/android/app/tauri.properties
+++ b/unime/src-tauri/gen-static/android/app/tauri.properties
@@ -1,1 +1,1 @@
-tauri.android.versionName=0.11.7
+tauri.android.versionName=0.12.0

--- a/unime/src-tauri/gen-static/apple/unime_iOS/Info.plist
+++ b/unime/src-tauri/gen-static/apple/unime_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.7</string>
+	<string>0.12.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -50,7 +50,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.11.7</string>
+	<string>0.12.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/unime/src-tauri/tauri.conf.json
+++ b/unime/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "UniMe",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "identifier": "com.impierce.identity-wallet",
   "app": {
     "security": {

--- a/unime/src/routes/(app)/me/settings/about/+page.svelte
+++ b/unime/src/routes/(app)/me/settings/about/+page.svelte
@@ -79,7 +79,7 @@
     {/if}
     <section class="flex flex-col items-center">
       <h2 class="font-bold">{$LL.SETTINGS.SUPPORT.ABOUT.VERSION()}</h2>
-      <div class="mb-3">0.11.7</div>
+      <div class="mb-3">0.12.0</div>
       <div class="flex items-center">
         <p>{$LL.SETTINGS.SUPPORT.ABOUT.BUILT_WITH()}</p>
         <HeartFillIcon class="pl-1" />


### PR DESCRIPTION
# Description of change

- bump version strings to 0.12.0
- fix Android-specific imports (only used when `#[cfg(target_os = "android")]`)

## Links to any relevant issues

n/a

## How the change has been tested

App starts again without crashing on a physical device.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
