### PR TITLE
fix: resolve relative key IDs

### DIFF
--- a/identity-wallet/src/state/core_utils/helpers.rs
+++ b/identity-wallet/src/state/core_utils/helpers.rs
@@ -43,6 +43,25 @@ pub fn get_unverified_jwt_claims(jwt: &serde_json::Value) -> Result<serde_json::
         .ok_or(AppError::Error("Failed to decode JWT claims".to_string()))
 }
 
+/// This function resolves the key ID from the JWT header, and makes it absolute if it's a relative reference (starts with '#') by prepending the 'iss' claim from the JWT payload.
+pub fn resolve_key_id(jwt: &str) -> Result<String, AppError> {
+    let jwt_header = decode_header(jwt).map_err(|_| AppError::GetCredentialStatusError)?;
+    let mut key_id = jwt_header.kid.ok_or(AppError::GetCredentialStatusError)?;
+
+    if key_id.starts_with('#') {
+        let claims = get_unverified_jwt_claims(&serde_json::json!(jwt))?;
+        let iss = claims
+            .get("iss")
+            .ok_or(AppError::Error("Missing 'iss' claim".to_string()))?
+            .as_str()
+            .ok_or(AppError::Error("'iss' claim is not a string".to_string()))?;
+
+        key_id = format!("{iss}{key_id}");
+    }
+
+    Ok(key_id)
+}
+
 /// This function uses the credential in jwt format from the jwt_vc_json to resolve the issuer document.
 pub async fn get_issuer_document(resolver: &Resolver, credential_jwt: &Jwt) -> Option<CoreDocument> {
     let decoder = Decoder::new();
@@ -72,7 +91,7 @@ pub async fn get_issuer_document(resolver: &Resolver, credential_jwt: &Jwt) -> O
 /// Validate a jwt_vc_json, checks the JWT and the Issuer DID.
 pub async fn validate_jwt_vc_json(credential_jwt: &str, identity_manager: &IdentityManager) -> Result<Value, AppError> {
     let jwt_header = decode_header(credential_jwt).map_err(|_| AppError::GetCredentialStatusError)?;
-    let key_id = jwt_header.kid.ok_or(AppError::GetCredentialStatusError)?;
+    let key_id = resolve_key_id(credential_jwt)?;
 
     let public_key = identity_manager
         .subject
@@ -358,5 +377,48 @@ mod tests {
 
         let result = validate_credential_types(&invalid_ob3);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn resolve_key_id_with_relative_reference() {
+        // JWT with relative key_id (starts with '#')
+        let jwt =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6IiNteWtleSJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTppc3N1ZXIifQ.signature";
+        let result = resolve_key_id(jwt);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "did:example:issuer#mykey");
+    }
+
+    #[test]
+    fn resolve_key_id_with_absolute_reference() {
+        // JWT with absolute key_id (doesn't start with '#')
+        let jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpleGFtcGxlOmlzc3VlciNteWtleSJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTppc3N1ZXIifQ.signature";
+        let result = resolve_key_id(jwt);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "did:example:issuer#mykey");
+    }
+
+    #[test]
+    fn resolve_key_id_missing_kid() {
+        // JWT without kid in header
+        let jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTppc3N1ZXIifQ.signature";
+        let result = resolve_key_id(jwt);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_key_id_missing_iss_claim() {
+        // JWT with relative key_id but missing 'iss' claim
+        let jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6IiNteWtleSJ9.e30.signature";
+        let result = resolve_key_id(jwt);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_key_id_iss_not_string() {
+        // JWT with relative key_id but 'iss' claim is not a string
+        let jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6IiNteWtleSJ9.eyJpc3MiOjEyMzQ1fQ.signature";
+        let result = resolve_key_id(jwt);
+        assert!(result.is_err());
     }
 }

--- a/identity-wallet/src/state/credentials/reducers/refresh_credential_status.rs
+++ b/identity-wallet/src/state/credentials/reducers/refresh_credential_status.rs
@@ -4,7 +4,7 @@ use crate::{
     error::AppError,
     state::{
         actions::{listen, Action},
-        core_utils::{DateUtils, IdentityManager},
+        core_utils::{helpers::resolve_key_id, DateUtils, IdentityManager},
         credentials::{
             actions::refresh_credential_status::RefreshCredentialStatus, CredentialStatus, VerifiableCredentialRecord,
         },
@@ -162,7 +162,7 @@ pub async fn fetch_credential_status(
     .await?;
 
     let jwt_header = decode_header(&status_list_jwt).map_err(|_| AppError::GetCredentialStatusError)?;
-    let key_id = jwt_header.kid.ok_or(AppError::GetCredentialStatusError)?;
+    let key_id = resolve_key_id(&status_list_jwt)?;
 
     let public_key = identity_manager
         .subject

--- a/identity-wallet/src/subject.rs
+++ b/identity-wallet/src/subject.rs
@@ -94,16 +94,18 @@ impl oid4vc::oid4vc_core::Subject for Subject {
 #[async_trait]
 impl Verify for Subject {
     async fn public_key(&self, did_url: &str) -> anyhow::Result<Vec<u8>> {
-        let did_url = identity_iota::did::DIDUrl::parse(did_url).unwrap();
+        let did_url = identity_iota::did::DIDUrl::parse(did_url)?;
 
-        let document = self.resolver().await.resolve(did_url.did().as_str()).await.unwrap();
+        let document = self.resolver().await.resolve(did_url.did().as_str()).await?;
 
         let verification_method = document
             .resolve_method(
                 DIDUrlQuery::from(&did_url),
                 Some(identity_iota::verification::MethodScope::VerificationMethod),
             )
-            .unwrap();
+            .ok_or(anyhow::anyhow!(
+                "Failed to resolve verification method for DID URL: {did_url}"
+            ))?;
 
         // Try decode from `MethodData` directly, else use public JWK params.
         verification_method.data().try_decode().or_else(|_| {
@@ -129,7 +131,7 @@ impl Verify for Subject {
                     }
                     _ => None,
                 })
-                .ok_or(anyhow::anyhow!("Failed to decode public key for DID URL: {}", did_url))
+                .ok_or(anyhow::anyhow!("Failed to decode public key for DID URL: {did_url}"))
         })
     }
 }


### PR DESCRIPTION
# Description of change
Ensures that relative `kid`s are resolved to their absolute form by taking the `iss` value, e.g.:

JWT:
```json
// header
{
  "kid": "#0",
}
// payload
{
  "iss": "did:example:123"
}
```

then the value of `key_id` will be resolved to: `"did:example:123#0"` as described [here](https://www.w3.org/TR/did-1.0/#relative-did-urls).

## Links to any relevant issues
n/a

## How the change has been tested
Added several unit tests for `resolve_key_id`

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
