### PR TITLE
fix: add optional chaining for `credential_metadata` access

### DIFF
--- a/unime/src/routes/prompt/credential-offer/+page.svelte
+++ b/unime/src/routes/prompt/credential-offer/+page.svelte
@@ -90,8 +90,8 @@
       {#each Object.entries(credential_configurations) as [credential_configuration_id, credential_configuration]}
         <!-- TODO: bug: long list is not correctly displayed -->
         <ListItemCard
-          id={hash(credential_configuration.credential_metadata.display?.at(0)?.logo?.uri ?? '')}
-          title={credential_configuration.credential_metadata.display?.at(0)?.name ?? credential_configuration_id}
+          id={hash(credential_configuration.credential_metadata?.display?.at(0)?.logo?.uri ?? '')}
+          title={credential_configuration.credential_metadata?.display?.at(0)?.name ?? credential_configuration_id}
           isTempAsset={true}
         >
           <div slot="right" class="mr-2">


### PR DESCRIPTION
# Description of change
UniMe frontend freezes on the Credential Offer page when it encounters a Credential Configuration object that **does not** contain a `credential_metadata` property (bug introduced [here](https://github.com/impierce/identity-wallet/pull/692)). 

This fix adds the optional chaining operator (`?`) to ensure a fallback can be used instead.

## Links to any relevant issues
- https://github.com/impierce/identity-wallet/issues/729

## How the change has been tested
Manually tested against Credential Issuer Metadata issuer that includes a Credential Configuration **without** the `credential_metadata` property:
```json
    "test": {
      "format": "jwt_vc_json",
      "credential_definition": {
        "type": [
          "VerifiableCredential"
        ]
      },
      "cryptographic_binding_methods_supported": [
        "did:jwk",
        "did:key"
      ],
      "credential_signing_alg_values_supported": [
        "ES256",
        "EdDSA"
      ],
      "proof_types_supported": {
        "jwt": {
          "proof_signing_alg_values_supported": [
            "ES256",
            "EdDSA"
          ]
        }
      }
    },
```

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
