### PR TITLE
feat: support `jpg` image assets

### DIFF
--- a/identity-wallet/src/persistence.rs
+++ b/identity-wallet/src/persistence.rs
@@ -191,7 +191,7 @@ pub async fn download_asset(url: reqwest::Url, id: &str) -> Result<(), AppError>
         .get("content-type")
         .map(|header_value| match header_value.to_str().unwrap() {
             "image/png" => Ok("png"),
-            "image/jpeg" => Ok("jpg"),
+            "image/jpeg" | "image/jpg" => Ok("jpg"),
             "image/svg+xml" => Ok("svg"),
             _ => {
                 warn!("content_type is not supported: {header_value:?}");

--- a/identity-wallet/src/persistence.rs
+++ b/identity-wallet/src/persistence.rs
@@ -191,6 +191,7 @@ pub async fn download_asset(url: reqwest::Url, id: &str) -> Result<(), AppError>
         .get("content-type")
         .map(|header_value| match header_value.to_str().unwrap() {
             "image/png" => Ok("png"),
+            "image/jpeg" => Ok("jpg"),
             "image/svg+xml" => Ok("svg"),
             _ => {
                 warn!("content_type is not supported: {header_value:?}");

--- a/unime/src-tauri/tests/tests/assets_download.rs
+++ b/unime/src-tauri/tests/tests/assets_download.rs
@@ -61,7 +61,7 @@ async fn when_content_type_is_supported_then_download_should_start() {
 
     Mock::given(method("GET"))
         .and(path("/image"))
-        .respond_with(ResponseTemplate::new(200).set_body_raw(vec![], "image/svg+xml"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(vec![], "image/jpeg"))
         .expect(1)
         .mount(&mock_server)
         .await;
@@ -82,7 +82,7 @@ async fn when_content_type_is_not_supported_then_download_should_fail() {
 
     Mock::given(method("GET"))
         .and(path("/image.png")) // file extension is ignored (even if it's supported), only content-type is checked
-        .respond_with(ResponseTemplate::new(200).set_body_raw(vec![], "image/jpeg"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(vec![], "image/webp"))
         .expect(1)
         .mount(&mock_server)
         .await;


### PR DESCRIPTION
# Description of change
Adds support for downloading JPEG image assets in UniMe.
Remote image assets with `Content-Type: image/jpeg` are now accepted and stored with a `.jpg` extension. The asset download tests were updated so JPEG is covered as a supported content type.

## How the change has been tested

Ran:
```bash
cd unime/src-tauri
cargo test --test mod assets_download
```
Result: 4 passed.

Also ran:
`cargo fmt --check`

## Definition of Done checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes