### PR TITLE
fix: remove unused `current_user_prompt` from `send_credential_request`

### DIFF
--- a/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/send_credential_request.rs
@@ -56,13 +56,6 @@ pub async fn send_credential_request(state: AppState, action: Action) -> Result<
             .ok_or(MissingManagerError("identity"))?
             .wallet;
 
-        let current_user_prompt = state
-            .current_user_prompt
-            .clone()
-            .ok_or(MissingStateParameterError("current user prompt"))?;
-
-        info!("current_user_prompt: {current_user_prompt:?}");
-
         let (credential_offer, logo_uri) = match state.core_utils.active_flow.clone() {
             Some(ActiveFlow::Oid4vciOffer {
                 credential_offer,


### PR DESCRIPTION
# Description of change
In certain scenarios (during Issuance flows) `.ok_or(MissingStateParameterError("current user prompt"))?;` would return an error even though `current_user_prompt` is not a required variable for handling the `CredentialOffersSelected` action (anymore). Since the variable is only used for logging, it can be safely removed to prevent unnecessary early exits. 

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
