### PR TITLE
fix(tls): use `webpki-roots` for HTTP client and DID resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4947,7 +4947,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5511,7 +5511,6 @@ dependencies = [
  "p256 0.13.2",
  "reqwest 0.13.4",
  "rustls 0.23.31",
- "rustls-platform-verifier 0.6.1",
  "sd-jwt-payload",
  "serde",
  "serde_json",
@@ -5533,6 +5532,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "webpki-roots 0.26.11",
  "wiremock",
 ]
 
@@ -10492,7 +10492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -12541,7 +12541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15137,6 +15137,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ oid4vc = { git = "https://github.com/impierce/openid4vc", rev = "0a5090e" }
 rand = "0.8"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rustls-platform-verifier = { version = "0.6" }
+webpki-roots = "0.26"
 serde_json = "1.0"
 serial_test = "2.0"
 tempfile = "3.5.0"

--- a/identity-wallet/Cargo.toml
+++ b/identity-wallet/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "rustls",
 ] }
 rustls.workspace = true
-rustls-platform-verifier.workspace = true
+webpki-roots.workspace = true
 sd-jwt = { package = "sd-jwt-payload", version = "0.5.1", default-features = false, features = [
     "sha",
 ] }

--- a/identity-wallet/src/http_client.rs
+++ b/identity-wallet/src/http_client.rs
@@ -1,0 +1,25 @@
+use reqwest::Client;
+use tokio::sync::OnceCell;
+
+use crate::state::core_utils::tls_config;
+
+static HTTP_CLIENT: OnceCell<Client> = OnceCell::const_new();
+
+pub fn get_http_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .use_preconfigured_tls(tls_config())
+        .timeout(std::time::Duration::from_secs(2))
+}
+
+/// Returns a globally shared `reqwest::Client` configured with `webpki-roots` TLS.
+pub async fn get_http_client() -> Client {
+    HTTP_CLIENT
+        .get_or_init(|| async {
+            get_http_client_builder().build().unwrap_or_else(|err| {
+                log::error!("Failed to build reqwest client: {err}");
+                Client::new()
+            })
+        })
+        .await
+        .clone()
+}

--- a/identity-wallet/src/lib.rs
+++ b/identity-wallet/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod command;
 pub mod error;
+pub mod http_client;
 pub mod migrations;
 pub mod persistence;
 pub mod state;

--- a/identity-wallet/src/persistence.rs
+++ b/identity-wallet/src/persistence.rs
@@ -1,3 +1,4 @@
+use crate::http_client::get_http_client;
 use crate::migrations::apply_state_migrations;
 use crate::state::APP_STATE_VERSION;
 use crate::{error::AppError, state::AppState};
@@ -184,7 +185,7 @@ pub async fn download_asset(url: reqwest::Url, id: &str) -> Result<(), AppError>
         std::fs::create_dir(&tmp_dir)?;
     }
 
-    let response = reqwest::get(url.clone()).await?;
+    let response = get_http_client().await.get(url.clone()).send().await?;
 
     let file_extension = response
         .headers()

--- a/identity-wallet/src/state/core_utils/mod.rs
+++ b/identity-wallet/src/state/core_utils/mod.rs
@@ -1,18 +1,8 @@
 pub mod helpers;
 pub mod history_event;
 
-#[cfg(target_os = "android")]
-use log::info;
-#[cfg(target_os = "android")]
-use rustls::{client::danger::ServerCertVerifier, ClientConfig};
-#[cfg(target_os = "android")]
-use rustls::{
-    client::danger::{HandshakeSignatureValid, ServerCertVerified},
-    pki_types::{CertificateDer, ServerName, UnixTime},
-    DigitallySignedStruct, Error, SignatureScheme,
-};
-#[cfg(target_os = "android")]
-use rustls_platform_verifier::BuilderVerifierExt;
+use std::sync::Arc;
+use rustls::RootCertStore;
 use url::Url;
 
 use crate::command::Runtime;
@@ -27,84 +17,18 @@ use oid4vc::{
     oid4vp::oid4vp::OID4VP,
     siopv2::siopv2::SIOPv2,
 };
-#[cfg(target_os = "android")]
-use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
-// TODO: Warning! This is very unsafe, this is only used for Android builds to temporarily bypass certificate
-// verification! The problem with `rustls_platform_verifier` on Android is that the Android Trust Store seems to
-// require OCSP stapling, which not all servers support. `api.mainnet.iota.cafe` is one of those servers.
-// This should be replaced with a proper certificate verifier that is secure and works on Android.
-// More info: https://github.com/rustls/rustls-platform-verifier/pull/179
-#[cfg(target_os = "android")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct UnsafeCertVerifier;
+pub fn tls_config() -> rustls::ClientConfig {
+    let _ = rustls::crypto::ring::default_provider().install_default();
 
-#[cfg(target_os = "android")]
-impl ServerCertVerifier for UnsafeCertVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: UnixTime,
-    ) -> Result<ServerCertVerified, Error> {
-        Ok(ServerCertVerified::assertion())
-    }
+    let mut root_store = RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        rustls::crypto::aws_lc_rs::default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
-    }
-
-    fn requires_raw_public_keys(&self) -> bool {
-        false
-    }
-
-    fn root_hint_subjects(&self) -> Option<&[rustls::DistinguishedName]> {
-        None
-    }
-}
-
-#[cfg(target_os = "android")]
-pub async fn tls_config() -> anyhow::Result<rustls::ClientConfig> {
-    info!("Creating TLS config for Android");
-    let arc_crypto_provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
-
-    info!("Using crypto provider: {:?}", arc_crypto_provider);
-    let mut config = ClientConfig::builder_with_provider(arc_crypto_provider)
-        .with_safe_default_protocol_versions()?
-        .with_platform_verifier()?
-        .with_no_client_auth();
-
-    // TODO: implement a secure custom certificate verifier
-    config
-        .dangerous()
-        .set_certificate_verifier(Arc::new(UnsafeCertVerifier));
-
-    info!("TLS config created for Android");
-
-    Ok(config)
+    rustls::ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+        .with_safe_default_protocol_versions()
+        .expect("Failed to set default protocol versions")
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
 }
 
 /// `Oid4vciStage` represents the different stages of the OID4VCI flow that can be active within the application.

--- a/identity-wallet/src/state/core_utils/mod.rs
+++ b/identity-wallet/src/state/core_utils/mod.rs
@@ -1,8 +1,8 @@
 pub mod helpers;
 pub mod history_event;
 
-use std::sync::Arc;
 use rustls::RootCertStore;
+use std::sync::Arc;
 use url::Url;
 
 use crate::command::Runtime;

--- a/identity-wallet/src/state/credentials/reducers/refresh_credential_status.rs
+++ b/identity-wallet/src/state/credentials/reducers/refresh_credential_status.rs
@@ -1,14 +1,10 @@
 use std::time::Duration;
 
 use crate::{
-    error::AppError,
-    state::{
-        actions::{listen, Action},
-        core_utils::{DateUtils, IdentityManager},
-        credentials::{
-            actions::refresh_credential_status::RefreshCredentialStatus, CredentialStatus, VerifiableCredentialRecord,
+    error::AppError, http_client::get_http_client_builder, state::{
+        AppState, actions::{Action, listen}, core_utils::{DateUtils, IdentityManager}, credentials::{
+            CredentialStatus, VerifiableCredentialRecord, actions::refresh_credential_status::RefreshCredentialStatus,
         },
-        AppState,
     },
 };
 use jsonwebtoken::{decode_header, Algorithm, DecodingKey};
@@ -18,7 +14,7 @@ use oauth_tsl::{
     status_list::{StatusList, StatusType},
 };
 use oid4vc::oid4vc_core::{utils::did::extract_normalized_did_kid_from_jwt, Verify};
-use reqwest::{header, redirect::Policy, Client};
+use reqwest::{header, redirect::Policy};
 
 pub async fn refresh_credential_status(state: AppState, action: Action) -> Result<AppState, AppError> {
     if let Some(refresh_credential_status) = listen::<RefreshCredentialStatus>(action) {
@@ -207,7 +203,7 @@ pub async fn fetch_credential_status(
 pub async fn fetch_status_list(uri: &str, accept_header: StatusListTokenResponseType) -> Result<String, AppError> {
     // 3xx redirects should be followed, but infinite loops are caught after 5 redirects.
     // The timeout of 10 seconds is an estimated guess of how long a status list request should take at maximum.
-    let client = Client::builder()
+    let client = get_http_client_builder()
         .redirect(Policy::limited(5))
         .timeout(Duration::from_secs(10))
         .build()

--- a/identity-wallet/src/state/credentials/reducers/refresh_credential_status.rs
+++ b/identity-wallet/src/state/credentials/reducers/refresh_credential_status.rs
@@ -1,10 +1,15 @@
 use std::time::Duration;
 
 use crate::{
-    error::AppError, http_client::get_http_client_builder, state::{
-        AppState, actions::{Action, listen}, core_utils::{DateUtils, IdentityManager}, credentials::{
-            CredentialStatus, VerifiableCredentialRecord, actions::refresh_credential_status::RefreshCredentialStatus,
+    error::AppError,
+    http_client::get_http_client_builder,
+    state::{
+        actions::{listen, Action},
+        core_utils::{DateUtils, IdentityManager},
+        credentials::{
+            actions::refresh_credential_status::RefreshCredentialStatus, CredentialStatus, VerifiableCredentialRecord,
         },
+        AppState,
     },
 };
 use jsonwebtoken::{decode_header, Algorithm, DecodingKey};

--- a/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
+++ b/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
@@ -1,4 +1,5 @@
 use crate::error::AppError::{self, *};
+use crate::http_client::get_http_client;
 use crate::state::{
     actions::{listen, Action},
     credentials::actions::share_to_linkedin::ShareToLinkedIn,
@@ -205,7 +206,7 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
     info!("Public verifier DACT storage endpoint URL: {public_verifier_dact_endpoint_url}");
 
     // Before the public link is returned, the DACT needs to be stored by the verifier
-    let client = reqwest::Client::new();
+    let client = get_http_client().await;
     let response = client
         .post(&public_verifier_dact_endpoint_url)
         .header("Content-Type", "application/json")

--- a/identity-wallet/src/state/dev_mode/reducers/dragon_dynamic_profile.rs
+++ b/identity-wallet/src/state/dev_mode/reducers/dragon_dynamic_profile.rs
@@ -1,6 +1,7 @@
 use crate::{
     command,
     error::AppError,
+    http_client::get_http_client,
     state::{
         common::actions::reset::Reset,
         connections::actions::connection_accepted::ConnectionAccepted,
@@ -115,7 +116,8 @@ async fn add_credential(state: AppState) -> Result<AppState, AppError> {
         ]
     });
 
-    let response: CredentialResponse = reqwest::Client::new()
+    let response: CredentialResponse = get_http_client()
+        .await
         .post(url)
         .json(&payload)
         .send()
@@ -166,7 +168,8 @@ async fn add_connection(state: AppState) -> Result<AppState, AppError> {
         }
     });
 
-    let response: ConnectionResponse = reqwest::Client::new()
+    let response: ConnectionResponse = get_http_client()
+        .await
         .post(url)
         .json(&payload)
         .send()
@@ -204,7 +207,8 @@ async fn add_presentation_request(state: AppState) -> Result<AppState, AppError>
         "clientMetadata":{"logoUri":"https://staging.client.ngdil.com/imgs/kw1c-white.png","clientName":"Koning Willem I College"}
     });
 
-    let response: PresentationResponse = reqwest::Client::new()
+    let response: PresentationResponse = get_http_client()
+        .await
         .post(url)
         .json(&payload)
         .send()
@@ -250,7 +254,8 @@ async fn add_future_engineer(state: AppState) -> Result<AppState, AppError> {
 
     let payload = json!({"credential":"Future Engineer","issuer":"kw1c"});
 
-    let response: CredentialResponse = reqwest::Client::new()
+    let response: CredentialResponse = get_http_client()
+        .await
         .post(url)
         .json(&payload)
         .send()

--- a/identity-wallet/src/state/did/validate_domain_linkage.rs
+++ b/identity-wallet/src/state/did/validate_domain_linkage.rs
@@ -16,6 +16,8 @@ use serde_with::skip_serializing_none;
 use std::str::FromStr;
 use ts_rs::TS;
 
+use crate::http_client::get_http_client;
+
 #[skip_serializing_none]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, TS, Default)]
 #[ts(export, export_to = "bindings/user_prompt/ValidationResult.ts")]
@@ -144,7 +146,10 @@ async fn fetch_configuration(mut url: url::Url) -> Result<DomainLinkageConfigura
     info!("Fetching DID configuration from: {url}");
 
     // 2. Fetch the resource
-    let response = reqwest::get(url.clone())
+    let response = get_http_client()
+        .await
+        .get(url.clone())
+        .send()
         .await
         .map_err(|_| format!("failed to get response from resource url: {url}"))?;
 

--- a/identity-wallet/src/state/did/validate_linked_verifiable_presentations.rs
+++ b/identity-wallet/src/state/did/validate_linked_verifiable_presentations.rs
@@ -1,8 +1,11 @@
-use crate::state::{
-    core_utils::helpers::{download_logo, get_issuer_document, validate_credential_types},
-    did::{
-        extract_url_from_did_web,
-        validate_domain_linkage::{ValidationStatus, Verifier},
+use crate::{
+    http_client::get_http_client,
+    state::{
+        core_utils::helpers::{download_logo, get_issuer_document, validate_credential_types},
+        did::{
+            extract_url_from_did_web,
+            validate_domain_linkage::{ValidationStatus, Verifier},
+        },
     },
 };
 use did_manager::Resolver;
@@ -146,7 +149,10 @@ async fn validate_linked_verifiable_presentation(
     holder_document: &CoreDocument,
     linked_verifiable_presentation_url: Url,
 ) -> Option<DecodedJwtPresentation<Jwt>> {
-    let response = reqwest::get(linked_verifiable_presentation_url)
+    let response = get_http_client()
+        .await
+        .get(linked_verifiable_presentation_url)
+        .send()
         .await
         .inspect_err(|err| {
             warn!("Failed to retrieve linked verifiable presentation: {err}");
@@ -377,7 +383,7 @@ async fn get_logo_uri(
         for domain in validated_linked_domains.iter() {
             let well_known_endpoint = format!("{domain}.well-known/openid-credential-issuer");
             info!("Trying to fetch image uri from {well_known_endpoint} endpoint");
-            if let Ok(response) = reqwest::Client::new().get(&well_known_endpoint).send().await {
+            if let Ok(response) = get_http_client().await.get(&well_known_endpoint).send().await {
                 if let Ok(metadata) = response.json::<CredentialIssuerMetadata>().await {
                     logo_uri = metadata.display.as_deref().and_then(extract_logo_uri_from_display);
 
@@ -392,7 +398,7 @@ async fn get_logo_uri(
             // But this is no guarantee and the code below is one such workaround.
             let well_known_endpoint = format!("{domain}oid4vci/.well-known/openid-credential-issuer");
             info!("Trying to fetch image uri from {well_known_endpoint} endpoint");
-            if let Ok(response) = reqwest::Client::new().get(&well_known_endpoint).send().await {
+            if let Ok(response) = get_http_client().await.get(&well_known_endpoint).send().await {
                 if let Ok(metadata) = response.json::<CredentialIssuerMetadata>().await {
                     logo_uri = linked_verifiable_credential.credential.types.iter().find_map(|type_| {
                         info!("Trying to fetch image uri from Credential Configuration Supported: {type_}");

--- a/identity-wallet/src/state/qr_code/reducers/read_credential_offer.rs
+++ b/identity-wallet/src/state/qr_code/reducers/read_credential_offer.rs
@@ -114,8 +114,8 @@ pub async fn read_credential_offer(state: AppState, action: Action) -> Result<Ap
 
         download_credential_logos(&credential_configurations).await;
 
-        if let Some(logo_uri_str) = logo_uri.clone() {
-            download_logo(&logo_uri_str).await;
+        if let Some(logo_uri_str) = &logo_uri {
+            download_logo(logo_uri_str).await;
         } else {
             warn!("No logo URI found");
         }

--- a/identity-wallet/src/state/verified_data/reducers/mod.rs
+++ b/identity-wallet/src/state/verified_data/reducers/mod.rs
@@ -4,10 +4,16 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::{
-    error::AppError, http_client::get_http_client, state::{
-        AppState, VerifiedData, actions::{Action, listen}, qr_code::{actions::qrcode_scanned::QrCodeScanned, reducers::read_credential_offer::read_credential_offer}, verified_data::{
-            EmailVerification, actions::{RedeemCode, ResetEmailVerification, SendVerificationEmail, ServiceHealthCheck},
+    error::AppError,
+    http_client::get_http_client,
+    state::{
+        actions::{listen, Action},
+        qr_code::{actions::qrcode_scanned::QrCodeScanned, reducers::read_credential_offer::read_credential_offer},
+        verified_data::{
+            actions::{RedeemCode, ResetEmailVerification, SendVerificationEmail, ServiceHealthCheck},
+            EmailVerification,
         },
+        AppState, VerifiedData,
     },
 };
 

--- a/identity-wallet/src/state/verified_data/reducers/mod.rs
+++ b/identity-wallet/src/state/verified_data/reducers/mod.rs
@@ -4,15 +4,10 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::{
-    error::AppError,
-    state::{
-        actions::{listen, Action},
-        qr_code::{actions::qrcode_scanned::QrCodeScanned, reducers::read_credential_offer::read_credential_offer},
-        verified_data::{
-            actions::{RedeemCode, ResetEmailVerification, SendVerificationEmail, ServiceHealthCheck},
-            EmailVerification,
+    error::AppError, http_client::get_http_client, state::{
+        AppState, VerifiedData, actions::{Action, listen}, qr_code::{actions::qrcode_scanned::QrCodeScanned, reducers::read_credential_offer::read_credential_offer}, verified_data::{
+            EmailVerification, actions::{RedeemCode, ResetEmailVerification, SendVerificationEmail, ServiceHealthCheck},
         },
-        AppState, VerifiedData,
     },
 };
 
@@ -22,7 +17,8 @@ const EMAIL_VERIFICATION_SERVICE_API_KEY: &str = env!("EMAIL_VERIFICATION_SERVIC
 pub async fn check_service_health(state: AppState, action: Action) -> Result<AppState, AppError> {
     if let Some(action) = listen::<ServiceHealthCheck>(action) {
         info!("[>>>] {}", action.service);
-        let response = reqwest::Client::new()
+        let response = get_http_client()
+            .await
             .get(format!("{EMAIL_VERIFICATION_SERVICE_HOST}/healthz"))
             .header("X-API-KEY", EMAIL_VERIFICATION_SERVICE_API_KEY)
             .send()
@@ -67,7 +63,8 @@ pub async fn send_verification_email(state: AppState, action: Action) -> Result<
         let url = format!("{EMAIL_VERIFICATION_SERVICE_HOST}/api/verify");
         let body = json!({ "email": action.email });
         info!("[>>>] {url} {body}");
-        let response = reqwest::Client::new()
+        let response = crate::http_client::get_http_client()
+            .await
             .post(url)
             .header("X-API-KEY", EMAIL_VERIFICATION_SERVICE_API_KEY)
             .json(&body)
@@ -110,7 +107,8 @@ pub async fn redeem_code(state: AppState, action: Action) -> Result<AppState, Ap
         let url = format!("{EMAIL_VERIFICATION_SERVICE_HOST}/api/verify/{session_id}");
         let body = json!({ "code": action.code });
         info!("[>>>] {url} {body}");
-        let response = reqwest::Client::new()
+        let response = crate::http_client::get_http_client()
+            .await
             .post(url)
             .header("X-API-KEY", EMAIL_VERIFICATION_SERVICE_API_KEY)
             .json(&body)

--- a/identity-wallet/src/subject.rs
+++ b/identity-wallet/src/subject.rs
@@ -1,4 +1,3 @@
-#[cfg(target_os = "android")]
 use crate::state::core_utils::tls_config;
 use crate::stronghold::StrongholdManager;
 use anyhow::anyhow;
@@ -37,16 +36,9 @@ impl Subject {
 
     /// The private async function that contains the actual initialization logic.
     async fn initialize_resolver() -> Arc<Resolver> {
-        #[cfg(not(target_os = "android"))]
-        let resolver = Resolver::new();
-
         info!("Initializing resolver for Subject");
-
-        #[cfg(target_os = "android")]
-        let resolver = Resolver::new_with_options(Some(tls_config().await.unwrap()), None, None);
-
+        let resolver = Resolver::new_with_options(Some(tls_config()), None, None);
         info!("Resolver initialized");
-
         Arc::new(resolver)
     }
 

--- a/unime/src-tauri/src/lib.rs
+++ b/unime/src-tauri/src/lib.rs
@@ -1,6 +1,4 @@
 #[cfg(target_os = "android")]
-use iota_sdk::IotaClientBuilder;
-#[cfg(target_os = "android")]
 use jni::{
     objects::{JClass, JObject},
     JNIEnv,

--- a/unime/src-tauri/src/lib.rs
+++ b/unime/src-tauri/src/lib.rs
@@ -83,6 +83,12 @@ pub mod tauri_command {
     }
 }
 
+/// Called by `MainActivity.kt` during Android startup to initialize the Android
+/// platform certificate verifier environment.
+///
+/// Note: While the wallet application uses `webpki-roots` for its HTTP clients,
+/// transitive dependencies (such as `jsonrpsee` via `iota-sdk`) require this
+/// initialization when running on Android.
 #[cfg(target_os = "android")]
 #[no_mangle]
 pub extern "C" fn Java_com_impierce_identity_1wallet_MainActivity_java_1init(


### PR DESCRIPTION
# Description of change
Replaces `rustls-platform-verifier` with `webpki-roots` across all HTTP client calls and DID resolver initialization in `identity-wallet`.

On Android, `rustls-platform-verifier` delegates TLS certificate verification to Android's native Java `TrustManager`, which causes network request failures due to strict OCSP stapling requirements that many servers do not support. Switching to `webpki-roots` performs RFC-compliant certificate path verification directly in Rust using Mozilla's root CA store, providing deterministic TLS verification across platforms.

Additionally, standardizes all HTTP requests across the backend codebase to consistently use `crate::http_client::get_http_client()` and `get_http_client_builder()`.

## Links to any relevant issues
None

## How the change has been tested
- **Unit Tests**: Executed `cargo test -p identity-wallet --lib`; all 117 tests passed locally.
- **Workspace Checks**: Ran `cargo check -p identity-wallet` and `cargo check -p unime` with zero compilation errors.
- **Android Device Verification**: Built and deployed the release APK to a physical Android device to verify that network requests (including credential status list fetching and DID resolution) complete successfully without TLS revocation or OCSP errors.

## Definition of Done checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
