### PR TITLE
feat: enable public links for SD-JWT

### DIFF
--- a/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
+++ b/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
@@ -243,8 +243,9 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
 /// Step 3: Add the hardcoded /public/verify endpoint to the Trust Anchor's URL. TODO: in the future this should be either in DID services or Openid Fed metadata.
 pub async fn get_trusted_verifier_public_verification_endpoint(issuer_did: &str) -> Result<String, AppError> {
     // This test feature is added to avoid the need to set up an entire trust ecosystem to create a unit test for this file.
+    // This .env variable is managed programmatically by the unit test in this file, and is only used for testing purposes. It is not used in production.
     #[cfg(test)]
-    if let Ok(endpoint) = std::env::var("UNIME_TEST_PUBLIC_VERIFIER_ENDPOINT") {
+    if let Ok(endpoint) = std::env::var("TEST_PUBLIC_VERIFIER_ENDPOINT") {
         return Ok(endpoint);
     }
 

--- a/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
+++ b/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
@@ -242,6 +242,11 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
 /// Step 2: get the Trust Anchor's URL
 /// Step 3: Add the hardcoded /public/verify endpoint to the Trust Anchor's URL. TODO: in the future this should be either in DID services or Openid Fed metadata.
 pub async fn get_trusted_verifier_public_verification_endpoint(issuer_did: &str) -> Result<String, AppError> {
+    #[cfg(test)]
+    if let Ok(endpoint) = std::env::var("UNIME_TEST_PUBLIC_VERIFIER_ENDPOINT") {
+        return Ok(endpoint);
+    }
+
     let federation_client = FederationClient::new();
 
     let issuer_url = extract_url_from_did_web(issuer_did).ok_or(AppError::Error(format!(
@@ -316,5 +321,186 @@ fn algorithm_from_did(did: &str) -> Result<jsonwebtoken::Algorithm, AppError> {
         }
     } else {
         Err(AppError::Error(format!("Cannot derive algorithm from DID: {did}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::STRONGHOLD;
+    use crate::state::core_utils::{IdentityManager, Managers};
+    use crate::state::{SUPPORTED_DID_METHODS, SUPPORTED_SIGNING_ALGORITHMS};
+    use crate::stronghold::StrongholdManager;
+    use crate::subject::subject;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use jsonwebtoken::Algorithm;
+    use oid4vc::oid4vci::credential_format_profiles::CredentialFormats;
+    use oid4vc::{oid4vc_manager::ProviderManager, oid4vci::Wallet};
+    use serial_test::serial;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    fn build_jwt_with_kid(kid: &str) -> String {
+        let header =
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&json!({ "alg": "EdDSA", "typ": "JWT", "kid": kid })).unwrap());
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&json!({ "sub": "test" })).unwrap());
+        format!("{header}.{payload}.signature")
+    }
+
+    async fn setup_state_with_identity() -> Result<(AppState, String), AppError> {
+        let path = NamedTempFile::new()
+            .map_err(|e| AppError::Error(e.to_string()))?
+            .into_temp_path();
+        *STRONGHOLD.lock().unwrap() = path.as_os_str().into();
+
+        let password = "sup3rSecr3t".to_string();
+        let stronghold_manager = Arc::new(StrongholdManager::create(&password).map_err(StrongholdCreationError)?);
+        let subject = subject(stronghold_manager.clone(), password).await;
+
+        let provider_manager = ProviderManager::new(
+            subject.clone(),
+            Vec::from(SUPPORTED_DID_METHODS),
+            Vec::from(SUPPORTED_SIGNING_ALGORITHMS),
+        )
+        .map_err(OID4VCProviderManagerError)?;
+        let wallet: Wallet = Wallet::new(
+            subject.clone(),
+            Vec::from(SUPPORTED_DID_METHODS),
+            Vec::from(SUPPORTED_SIGNING_ALGORITHMS),
+        )
+        .map_err(OID4VCWalletError)?;
+
+        let own_did = subject
+            .identifier("did:key", Algorithm::EdDSA)
+            .await
+            .map_err(|e| AppError::Error(e.to_string()))?;
+
+        let state = AppState {
+            core_utils: crate::state::core_utils::CoreUtils {
+                app_handle: None,
+                managers: Arc::new(tauri::async_runtime::Mutex::new(Managers {
+                    stronghold_manager: Some(stronghold_manager),
+                    identity_manager: Some(IdentityManager {
+                        subject,
+                        provider_manager,
+                        wallet,
+                    }),
+                })),
+                active_flow: None,
+            },
+            ..Default::default()
+        };
+
+        Ok((state, own_did))
+    }
+
+    async fn assert_public_link_creation_for_format(format: CredentialFormats) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/store-data-access-consent-token"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        std::env::set_var(
+            "UNIME_TEST_PUBLIC_VERIFIER_ENDPOINT",
+            format!("{}/verify", mock_server.uri()),
+        );
+
+        let result = async {
+            let (state, own_did) = setup_state_with_identity().await.unwrap();
+
+            let credential_key = Uuid::new_v4();
+            let kid = "did:web:issuer.example#key-1";
+            let jwt = build_jwt_with_kid(kid);
+
+            let vcr = VerifiableCredentialRecord {
+                verifiable_credential: json!(jwt),
+                display_credential: crate::state::credentials::DisplayCredential {
+                    id: credential_key.to_string(),
+                    format,
+                    data: json!({
+                        "id": format!("urn:uuid:{credential_key}"),
+                        "credentialSubject": {
+                            "id": own_did
+                        }
+                    }),
+                    issuer_name: "Issuer".to_string(),
+                    display_name: "Credential".to_string(),
+                    ..Default::default()
+                },
+            };
+
+            let managers = state.core_utils.managers.lock().await;
+            let stronghold_manager = managers.stronghold_manager.as_ref().unwrap();
+            stronghold_manager
+                .insert(credential_key, serde_json::to_vec(&vcr).unwrap())
+                .unwrap();
+            drop(managers);
+
+            let public_link = create_public_link(&state, &credential_key.to_string()).await.unwrap();
+            assert!(public_link
+                .as_str()
+                .starts_with(&format!("{}/verify/", mock_server.uri())));
+        }
+        .await;
+
+        std::env::remove_var("UNIME_TEST_PUBLIC_VERIFIER_ENDPOINT");
+        result
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn create_public_link_from_jwt_vc_json() {
+        assert_public_link_creation_for_format(CredentialFormats::JwtVcJson(())).await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn create_public_link_from_dc_sd_jwt() {
+        assert_public_link_creation_for_format(CredentialFormats::DcSdJwt(())).await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn create_public_link_from_vc_sd_jwt() {
+        assert_public_link_creation_for_format(CredentialFormats::VcSdJwt(())).await;
+    }
+
+    #[cfg(feature = "test_utils")]
+    #[tokio::test]
+    async fn share_to_linkedin_reducer_finishes_successfully() {
+        let credential_id = Uuid::new_v4().to_string();
+        let existing_public_link = "https://example.com/verify/existing".to_string();
+
+        let state = AppState {
+            credentials: vec![crate::state::credentials::DisplayCredential {
+                id: credential_id.clone(),
+                issuer_name: "Issuer".to_string(),
+                display_name: "Credential".to_string(),
+                metadata: crate::state::credentials::CredentialMetadata {
+                    date_issued: "2026-01-01T00:00:00Z".to_string(),
+                    ..Default::default()
+                },
+                public_link: Some(existing_public_link.clone()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let action: Action = Arc::new(ShareToLinkedIn { id: credential_id });
+        let updated_state = share_to_linkedin(state, action).await.unwrap();
+
+        assert_eq!(updated_state.credentials.len(), 1);
+        assert_eq!(
+            updated_state.credentials[0].public_link.as_deref(),
+            Some(existing_public_link.as_str())
+        );
     }
 }

--- a/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
+++ b/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
@@ -242,6 +242,7 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
 /// Step 2: get the Trust Anchor's URL
 /// Step 3: Add the hardcoded /public/verify endpoint to the Trust Anchor's URL. TODO: in the future this should be either in DID services or Openid Fed metadata.
 pub async fn get_trusted_verifier_public_verification_endpoint(issuer_did: &str) -> Result<String, AppError> {
+    // This test feature is added to avoid the need to set up an entire trust ecosystem to create a unit test for this file.
     #[cfg(test)]
     if let Ok(endpoint) = std::env::var("UNIME_TEST_PUBLIC_VERIFIER_ENDPOINT") {
         return Ok(endpoint);

--- a/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
+++ b/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
@@ -10,11 +10,7 @@ use base64::Engine;
 use chrono::{DateTime, Datelike, Duration, Utc};
 use jsonwebtoken::Header;
 use log::info;
-use oid4vc::oid4vc_core::{
-    jwt::encode,
-    utils::{did::extract_normalized_did_kid_from_jwt, jwt::get_unverified_jwt_claims},
-    Subject,
-};
+use oid4vc::oid4vc_core::{jwt::encode, utils::did::extract_normalized_did_kid_from_jwt, Subject};
 use openid_federation::FederationClient;
 use serde::Serialize;
 use serde_json::json;
@@ -118,7 +114,7 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
     let vcr: VerifiableCredentialRecord =
         serde_json::from_slice(&vcr_bytes).map_err(|e| AppError::Error(e.to_string()))?;
     let jwt = &mut vcr.verifiable_credential.clone();
-    let jwt_data = get_unverified_jwt_claims(jwt).map_err(|e| AppError::Error(e.to_string()))?;
+
     let jwt_str = jwt.as_str().map(ToString::to_string).ok_or(AppError::Error(
         "Failed to convert the Public Link credential JWT to a string".to_string(),
     ))?;
@@ -129,9 +125,10 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
     let credential_issuer_did = kid.split('#').next().unwrap_or(&kid); // A did:web needs a # key fragment, a did:key doesn't
 
     // Get the credential's subject ID. This means anonymous credentials (without a credentialSubject.id) cannot be shared publicly.
-    let credential_subject_id = jwt_data
-        .get("vc")
-        .and_then(|v| v.get("credentialSubject"))
+    let credential_subject_id = vcr
+        .display_credential
+        .data
+        .get("credentialSubject")
         .and_then(|v| v.get("id"))
         .and_then(|v| v.as_str())
         .ok_or(AppError::Error(
@@ -163,10 +160,13 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
     };
 
     // Get the JTI claim from the credential data
-    let jti = jwt_data
-        .get("jti")
+    let credential_id = vcr
+        .display_credential
+        .data
+        .get("id")
         .and_then(|v| v.as_str())
         .ok_or(AppError::Error("JTI not found".to_string()))?;
+
     let token_jti = Uuid::new_v4().to_string();
     let now = Utc::now();
     // TODO: this is a hardcoded expiration date of 1 year after issuance.
@@ -174,7 +174,7 @@ async fn create_public_link(state: &AppState, credential_id: &str) -> Result<Url
 
     let claims = PublicLinkTokenClaims {
         iss: credential_subject_id.to_string(), // This is the same as setting it to own_did, since the check above validates whether our own did which we will use for signing this DACT is the same as the credentialSubject.id.
-        sub: jti.to_string(),
+        sub: credential_id.to_string(),
         aud: credential_issuer_did.to_string(),
         iat: now.timestamp(),
         nbf: now.timestamp(),
@@ -252,7 +252,7 @@ pub async fn get_trusted_verifier_public_verification_endpoint(issuer_did: &str)
         .await
         .map_err(|e| {
             AppError::Error(format!(
-                "Failed to discover a trusted trust_anchor for Issuer of credential to be shared: {e}"
+                "Failed to discover a trusted trust_anchor for Issuer {issuer_url} of credential to be shared: {e}"
             ))
         })?;
 

--- a/identity-wallet/src/state/did/mod.rs
+++ b/identity-wallet/src/state/did/mod.rs
@@ -20,7 +20,7 @@ pub fn extract_url_from_did_web(did_web: &str) -> Option<Url> {
         let url_decoded = urlencoding::decode(url_str);
 
         if let Ok(url_decoded) = url_decoded {
-            if let Ok(url) = Url::parse(&format!("https://{url_decoded}")) {
+            if let Ok(url) = Url::parse(&format!("http://{url_decoded}")) {
                 return Some(url);
             }
         }

--- a/identity-wallet/src/state/did/mod.rs
+++ b/identity-wallet/src/state/did/mod.rs
@@ -20,7 +20,7 @@ pub fn extract_url_from_did_web(did_web: &str) -> Option<Url> {
         let url_decoded = urlencoding::decode(url_str);
 
         if let Ok(url_decoded) = url_decoded {
-            if let Ok(url) = Url::parse(&format!("http://{url_decoded}")) {
+            if let Ok(url) = Url::parse(&format!("https://{url_decoded}")) {
                 return Some(url);
             }
         }


### PR DESCRIPTION
# Description of change
This PR enables public links for sd-jwt mainly by improving the parsing of the selected credential to adequately retrieve all the necessary data for the DACT creation.

## Links to any relevant issues

## How the change has been tested
I've added tests for the succesfull creation of the public link for the 3 different credential formats: jwt_vc_json, dc+sd-jwt and vc+sd-jwt. Another test for succesfully completing the share_to_linkedin action.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
