### PR TITLE
fix: use pre-configured `reqwest` client for trust chain resolution

### DIFF
--- a/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
+++ b/identity-wallet/src/state/credentials/reducers/share_to_linkedin.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Datelike, Duration, Utc};
 use jsonwebtoken::Header;
 use log::info;
 use oid4vc::oid4vc_core::{jwt::encode, utils::did::extract_normalized_did_kid_from_jwt, Subject};
-use openid_federation::FederationClient;
+use openid_federation::{FederationClient, ReqwestHttpClient};
 use serde::Serialize;
 use serde_json::json;
 use std::str::FromStr;
@@ -249,7 +249,7 @@ pub async fn get_trusted_verifier_public_verification_endpoint(issuer_did: &str)
         return Ok(endpoint);
     }
 
-    let federation_client = FederationClient::new();
+    let federation_client = FederationClient::with_http_client(ReqwestHttpClient::with_client(get_http_client().await));
 
     let issuer_url = extract_url_from_did_web(issuer_did).ok_or(AppError::Error(format!(
         "Failed to extract URL from issuer DID: {issuer_did}"


### PR DESCRIPTION
# Description of change
UniMe fails to validate the Trust Chain on Android due to the FederationClient using the wrong TLS settings (by default). 

This change updates `get_trusted_verifier_public_verification_endpoint` to instantiate `FederationClient` using the application's shared `ReqwestHttpClient` via `get_http_client().await`. This ensures OpenID Federation trust chain discovery requests inherit the wallet's custom TLS configuration (webpki-roots) and timeout settings required on mobile platforms (specifically Android).

## Links to any relevant issues
n/a

## How the change has been tested
Manually tested on an Adnroid device

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
