### PR TITLE
fix: support `vc+sd-jwt` credentials in OID4VP flow

### DIFF
--- a/identity-wallet/src/state/credentials/reducers/handle_oid4vp_authorization_request.rs
+++ b/identity-wallet/src/state/credentials/reducers/handle_oid4vp_authorization_request.rs
@@ -235,6 +235,21 @@ pub async fn build_oid4vp_vp_token_and_history_credentials(
                         .into_disclosed_object(&Sha256Hasher::new())
                         .map_err(|e| AppError::Error(format!("Failed to get disclosed object from SD-JWT VC: {e}")))?;
                     serde_json::json!(disclosed_object)
+                } else if verifiable_credential_record.display_credential.format == CredentialFormats::VcSdJwt(()) {
+                    let sd_jwt_string = verifiable_credential_record
+                        .verifiable_credential
+                        .as_str()
+                        .ok_or(AppError::InvalidCredentialFormatError)?
+                        .to_string();
+
+                    let sd_jwt = sd_jwt_string
+                        .parse::<SdJwt>()
+                        .map_err(|e| AppError::Error(format!("Failed to parse stored SD-JWT: {e}")))?;
+
+                    let disclosed_object = sd_jwt
+                        .into_disclosed_object(&Sha256Hasher::new())
+                        .map_err(|e| AppError::Error(format!("Failed to get disclosed object from SD-JWT: {e}")))?;
+                    serde_json::json!(disclosed_object)
                 } else if verifiable_credential_record.display_credential.format == CredentialFormats::JwtVcJson(()) {
                     get_unverified_jwt_claims(&verifiable_credential_record.verifiable_credential)
                         .unwrap_or_default()


### PR DESCRIPTION
# Description of change
Adds support for `CredentialFormats::VcSdJwt` when extracting disclosed claims during OID4VP authorization request processing in `build_oid4vp_vp_token_and_history_credentials`. Previously, only `dc+sd-jwt` and `jwt_vc_json` formats were handled here, causing stored `vc+sd-jwt` credentials to fall back to the unhandled case.

## Links to any relevant issues
<!-- Add if applicable, e.g. fixes issue # -->

## How the change has been tested
Tested locally via Tauri dev build (`cargo tauri dev`) by initiating an OID4VP flow presenting a `vc+sd-jwt` credential and verifying that disclosed claims are parsed and handled correctly.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
