### PR TITLE
fix: make ESCO skill definition links clickable on mobile

### DIFF
--- a/unime/src-tauri/capabilities/main.json
+++ b/unime/src-tauri/capabilities/main.json
@@ -7,6 +7,8 @@
     "deep-link:default",
     "fs:default",
     "log:default",
+    "opener:allow-open-url",
+    "opener:allow-default-urls",
     "shell:allow-open",
     {
       "identifier": "fs:allow-exists",

--- a/unime/src-tauri/capabilities/mobile.json
+++ b/unime/src-tauri/capabilities/mobile.json
@@ -3,5 +3,11 @@
   "identifier": "mobile-capability",
   "windows": ["main"],
   "platforms": ["iOS", "android"],
-  "permissions": ["barcode-scanner:default", "biometric:default", "keystore:default", "opener:allow-default-urls"]
+  "permissions": [
+    "barcode-scanner:default",
+    "biometric:default",
+    "keystore:default",
+    "opener:allow-open-url",
+    "opener:allow-default-urls"
+  ]
 }

--- a/unime/src/routes/credentials/[id]/(renderers)/AlignmentRenderer.svelte
+++ b/unime/src/routes/credentials/[id]/(renderers)/AlignmentRenderer.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import LL from '$i18n/i18n-svelte';
+  import { openUrl } from '@tauri-apps/plugin-opener';
+  import { error as logError } from '@tauri-apps/plugin-log';
   import markdownit from 'markdown-it';
 
   import { ArrowSquareOutBoldIcon, SealCheckFillIcon } from '$lib/icons';
@@ -16,6 +18,15 @@
       : skill?.kind === 'occupation'
         ? $LL.CREDENTIAL.DETAILS.OPEN_BADGES.OCCUPATION()
         : null;
+
+  async function openLink(url?: string | null) {
+    if (!url) return;
+    try {
+      await openUrl(url);
+    } catch (e) {
+      logError(`Failed to open URL ${url}: ${e}`);
+    }
+  }
 </script>
 
 <!--
@@ -56,6 +67,7 @@ these, so it is rendered as its name and description alone.
             href={skill.url}
             target="_blank"
             rel="noopener noreferrer"
+            on:click|preventDefault={() => openLink(skill.url)}
             class="ml-auto flex shrink-0 items-center gap-1 text-[11px]/[20px] font-medium underline"
           >
             {$LL.CREDENTIAL.DETAILS.OPEN_BADGES.FRAMEWORK_LINK()}

--- a/unime/src/routes/credentials/[id]/(renderers)/AlignmentRenderer.svelte
+++ b/unime/src/routes/credentials/[id]/(renderers)/AlignmentRenderer.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import LL from '$i18n/i18n-svelte';
-  import { openUrl } from '@tauri-apps/plugin-opener';
-  import { error as logError } from '@tauri-apps/plugin-log';
   import markdownit from 'markdown-it';
+
+  import { error as logError } from '@tauri-apps/plugin-log';
+  import { openUrl } from '@tauri-apps/plugin-opener';
 
   import { ArrowSquareOutBoldIcon, SealCheckFillIcon } from '$lib/icons';
   import { findOfficialSkill, type Alignment } from '$lib/utils/alignment';


### PR DESCRIPTION
# Description of change
As title

## Links to any relevant issues
n/a

## How the change has been tested
Manually tested on Android

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Framework links in credential views now open through the app’s supported link-handling flow.
  - Added support for opening URLs on desktop and mobile platforms.

- **Bug Fixes**
  - Links without a valid URL are safely ignored.
  - Prevented duplicate browser navigation when opening framework links.
  - Improved handling of link-opening failures without disrupting the page experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->